### PR TITLE
refactor: modernize client, add tests and new API endpoints

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -10,6 +10,7 @@ type loginResponse struct {
 	Auth string `json:"auth"`
 }
 
+// Login authenticates with username and password, storing the session token on the client.
 func (c *Client) Login(ctx context.Context, username, password string) error {
 	params := url.Values{
 		"getauth":  {"1"},
@@ -26,6 +27,7 @@ func (c *Client) Login(ctx context.Context, username, password string) error {
 	return nil
 }
 
+// Logout invalidates the current session token.
 func (c *Client) Logout(ctx context.Context) error {
 	var resp Error
 	if err := c.do(ctx, "logout", url.Values{}, &resp); err != nil {
@@ -36,6 +38,7 @@ func (c *Client) Logout(ctx context.Context) error {
 	return nil
 }
 
+// UserInfo returns the account details for the authenticated user.
 func (c *Client) UserInfo(ctx context.Context) (*UserInfo, error) {
 	var resp UserInfo
 	if err := c.do(ctx, "userinfo", url.Values{}, &resp); err != nil {

--- a/client.go
+++ b/client.go
@@ -15,12 +15,18 @@ import (
 )
 
 const (
-	BaseURLUS      = "https://api.pcloud.com"
-	BaseURLEU      = "https://eapi.pcloud.com"
-	DefaultRPM     = 100.0
+	// BaseURLUS is the pCloud API endpoint for US-region accounts.
+	BaseURLUS = "https://api.pcloud.com"
+	// BaseURLEU is the pCloud API endpoint for EU-region accounts.
+	BaseURLEU = "https://eapi.pcloud.com"
+	// MinRPM is the minimum allowed rate limit in requests per minute.
+	MinRPM = 100.0
+	// DefaultTimeout is the default HTTP client timeout.
 	DefaultTimeout = 30 * time.Second
 )
 
+// Client is a pCloud API client. Use NewClient to create one.
+// All methods are safe for concurrent use.
 type Client struct {
 	baseURL     string
 	httpClient  *http.Client
@@ -30,6 +36,8 @@ type Client struct {
 	limiter     *rate.Limiter
 }
 
+// NewClient creates a new Client for the given base URL.
+// Pass BaseURLUS or BaseURLEU; an empty string defaults to BaseURLUS.
 func NewClient(baseURL string) *Client {
 	if baseURL == "" {
 		baseURL = BaseURLUS
@@ -38,26 +46,32 @@ func NewClient(baseURL string) *Client {
 		baseURL:    baseURL,
 		httpClient: &http.Client{Timeout: DefaultTimeout},
 		logger:     newNoopLogger(),
-		limiter:    rate.NewLimiter(rate.Limit(DefaultRPM/60.0), 1),
+		limiter:    rate.NewLimiter(rate.Limit(MinRPM/60.0), 10),
 	}
 }
 
+// SetHTTPClient replaces the default HTTP client.
 func (c *Client) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
 }
 
+// SetLogger attaches a structured logger for request diagnostics.
 func (c *Client) SetLogger(logger *slog.Logger) {
 	c.logger = logger
 }
 
+// SetRateLimit configures the maximum requests per minute.
+// Returns an error if rpm is below MinRPM.
 func (c *Client) SetRateLimit(rpm float64) error {
-	if rpm < DefaultRPM {
-		return fmt.Errorf("rate limit %.1f RPM is below minimum %.1f RPM", rpm, DefaultRPM)
+	if rpm < MinRPM {
+		return fmt.Errorf("rate limit %.1f RPM is below minimum %.1f RPM", rpm, MinRPM)
 	}
-	c.limiter = rate.NewLimiter(rate.Limit(rpm/60.0), 1)
+	c.limiter = rate.NewLimiter(rate.Limit(rpm/60.0), 10)
 	return nil
 }
 
+// SetTokenSource configures OAuth2 token-based authentication.
+// This takes precedence over username/password auth set via Login.
 func (c *Client) SetTokenSource(ts oauth2.TokenSource) {
 	c.tokenSource = ts
 }

--- a/client.go
+++ b/client.go
@@ -86,19 +86,8 @@ func (c *Client) do(ctx context.Context, method string, params url.Values, resul
 	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
-		if resp.StatusCode != http.StatusOK {
-			c.logger.Error("request failed", "method", method, "status", resp.Status)
-			return fmt.Errorf("request failed: %s", resp.Status)
-		}
 		c.logger.Error("decode failed", "method", method, "error", err)
 		return err
-	}
-	if resp.StatusCode != http.StatusOK {
-		if err := result.Err(); err != nil {
-			return err
-		}
-		c.logger.Error("request failed", "method", method, "status", resp.Status)
-		return fmt.Errorf("request failed: %s", resp.Status)
 	}
 	return result.Err()
 }
@@ -128,19 +117,8 @@ func (c *Client) doPost(ctx context.Context, method string, params url.Values, b
 	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
-		if resp.StatusCode != http.StatusOK {
-			c.logger.Error("request failed", "method", method, "status", resp.Status)
-			return fmt.Errorf("request failed: %s", resp.Status)
-		}
 		c.logger.Error("decode failed", "method", method, "error", err)
 		return err
-	}
-	if resp.StatusCode != http.StatusOK {
-		if err := result.Err(); err != nil {
-			return err
-		}
-		c.logger.Error("request failed", "method", method, "status", resp.Status)
-		return fmt.Errorf("request failed: %s", resp.Status)
 	}
 	return result.Err()
 }

--- a/client.go
+++ b/client.go
@@ -62,65 +62,45 @@ func (c *Client) SetTokenSource(ts oauth2.TokenSource) {
 	c.tokenSource = ts
 }
 
-func (c *Client) do(ctx context.Context, method string, params url.Values, result apiError) error {
+func (c *Client) request(ctx context.Context, httpMethod, apiMethod string, params url.Values, body io.Reader, contentType string, result apiError) error {
 	if err := c.setAuth(params); err != nil {
 		return err
 	}
 
-	c.logger.Debug("request", "method", method)
+	c.logger.Debug("request", "method", apiMethod)
 	if err := c.limiter.Wait(ctx); err != nil {
 		return err
 	}
 
-	reqURL := fmt.Sprintf("%s/%s?%s", c.baseURL, method, params.Encode())
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	reqURL := fmt.Sprintf("%s/%s?%s", c.baseURL, apiMethod, params.Encode())
+	req, err := http.NewRequestWithContext(ctx, httpMethod, reqURL, body)
 	if err != nil {
 		return err
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		c.logger.Error("request failed", "method", method, "error", err)
+		c.logger.Error("request failed", "method", apiMethod, "error", err)
 		return err
 	}
 	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
-		c.logger.Error("decode failed", "method", method, "error", err)
+		c.logger.Error("decode failed", "method", apiMethod, "error", err)
 		return err
 	}
 	return result.Err()
 }
 
+func (c *Client) do(ctx context.Context, method string, params url.Values, result apiError) error {
+	return c.request(ctx, http.MethodGet, method, params, nil, "", result)
+}
+
 func (c *Client) doPost(ctx context.Context, method string, params url.Values, body io.Reader, contentType string, result apiError) error {
-	if err := c.setAuth(params); err != nil {
-		return err
-	}
-
-	c.logger.Debug("request", "method", method)
-	if err := c.limiter.Wait(ctx); err != nil {
-		return err
-	}
-
-	reqURL := fmt.Sprintf("%s/%s?%s", c.baseURL, method, params.Encode())
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, body)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", contentType)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		c.logger.Error("request failed", "method", method, "error", err)
-		return err
-	}
-	defer resp.Body.Close()
-
-	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
-		c.logger.Error("decode failed", "method", method, "error", err)
-		return err
-	}
-	return result.Err()
+	return c.request(ctx, http.MethodPost, method, params, body, contentType, result)
 }
 
 func (c *Client) setAuth(params url.Values) error {

--- a/client.go
+++ b/client.go
@@ -8,15 +8,17 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/time/rate"
 )
 
 const (
-	BaseURLUS  = "https://api.pcloud.com"
-	BaseURLEU  = "https://eapi.pcloud.com"
-	DefaultRPM = 100.0
+	BaseURLUS      = "https://api.pcloud.com"
+	BaseURLEU      = "https://eapi.pcloud.com"
+	DefaultRPM     = 100.0
+	DefaultTimeout = 30 * time.Second
 )
 
 type Client struct {
@@ -34,7 +36,7 @@ func NewClient(baseURL string) *Client {
 	}
 	return &Client{
 		baseURL:    baseURL,
-		httpClient: http.DefaultClient,
+		httpClient: &http.Client{Timeout: DefaultTimeout},
 		logger:     newNoopLogger(),
 		limiter:    rate.NewLimiter(rate.Limit(DefaultRPM/60.0), 1),
 	}
@@ -84,8 +86,19 @@ func (c *Client) do(ctx context.Context, method string, params url.Values, resul
 	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		if resp.StatusCode != http.StatusOK {
+			c.logger.Error("request failed", "method", method, "status", resp.Status)
+			return fmt.Errorf("request failed: %s", resp.Status)
+		}
 		c.logger.Error("decode failed", "method", method, "error", err)
 		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		if err := result.Err(); err != nil {
+			return err
+		}
+		c.logger.Error("request failed", "method", method, "status", resp.Status)
+		return fmt.Errorf("request failed: %s", resp.Status)
 	}
 	return result.Err()
 }
@@ -115,8 +128,19 @@ func (c *Client) doPost(ctx context.Context, method string, params url.Values, b
 	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		if resp.StatusCode != http.StatusOK {
+			c.logger.Error("request failed", "method", method, "status", resp.Status)
+			return fmt.Errorf("request failed: %s", resp.Status)
+		}
 		c.logger.Error("decode failed", "method", method, "error", err)
 		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		if err := result.Err(); err != nil {
+			return err
+		}
+		c.logger.Error("request failed", "method", method, "status", resp.Status)
+		return fmt.Errorf("request failed: %s", resp.Status)
 	}
 	return result.Err()
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,61 @@
+package pcloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestNewClientDefaultURL(t *testing.T) {
+	c := NewClient("")
+	if c.baseURL != BaseURLUS {
+		t.Fatalf("want %q, got %q", BaseURLUS, c.baseURL)
+	}
+}
+
+func TestSetRateLimitBelowMin(t *testing.T) {
+	c := NewClient("")
+	if err := c.SetRateLimit(DefaultRPM - 1); err == nil {
+		t.Fatal("expected error for rate below DefaultRPM")
+	}
+}
+
+func TestSetRateLimitValid(t *testing.T) {
+	c := NewClient("")
+	if err := c.SetRateLimit(DefaultRPM); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestAuthInjected(t *testing.T) {
+	var gotAuth string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.URL.Query().Get("auth")
+		json.NewEncoder(w).Encode(Error{Result: 0})
+	})
+
+	var resp Error
+	if err := c.do(context.Background(), "ping", url.Values{}, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "test-token" {
+		t.Fatalf("want auth=test-token, got %q", gotAuth)
+	}
+}
+
+func TestRequestAPIError(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(Error{Result: 2005, Message: "not found"})
+	})
+
+	var resp Error
+	err := c.do(context.Background(), "stat", url.Values{}, &resp)
+	if err == nil {
+		t.Fatal("expected error from API result=2005")
+	}
+	if err.Error() != "pcloud error 2005: not found" {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -17,14 +17,14 @@ func TestNewClientDefaultURL(t *testing.T) {
 
 func TestSetRateLimitBelowMin(t *testing.T) {
 	c := NewClient("")
-	if err := c.SetRateLimit(DefaultRPM - 1); err == nil {
-		t.Fatal("expected error for rate below DefaultRPM")
+	if err := c.SetRateLimit(MinRPM - 1); err == nil {
+		t.Fatal("expected error for rate below MinRPM")
 	}
 }
 
 func TestSetRateLimitValid(t *testing.T) {
 	c := NewClient("")
-	if err := c.SetRateLimit(DefaultRPM); err != nil {
+	if err := c.SetRateLimit(MinRPM); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -62,4 +62,38 @@
 //	    }
 //	    fmt.Println(item.Path)
 //	}
+//
+// # Trash
+//
+// List, restore, and empty the trash:
+//
+//	ctx := context.Background()
+//	items, _ := c.ListTrash(ctx)
+//	c.RestoreFromTrash(ctx, fileID)
+//	c.EmptyTrash(ctx)
+//
+// # Search
+//
+// Search for files by name:
+//
+//	ctx := context.Background()
+//	results, _ := c.Search(ctx, "report", nil)
+//	results, _ = c.Search(ctx, "img", &pcloud.SearchOpts{FolderID: 10, Recursive: true})
+//
+// # Thumbnails
+//
+// Generate image thumbnails:
+//
+//	ctx := context.Background()
+//	link, _ := c.GetThumbnail(ctx, fileID, 200, 200, nil)
+//	link, _ = c.GetThumbnailByPath(ctx, "/photo.jpg", 128, 128, &pcloud.ThumbOpts{Crop: true})
+//
+// # Favorites
+//
+// Manage starred files:
+//
+//	ctx := context.Background()
+//	c.AddFavorite(ctx, fileID)
+//	favorites, _ := c.ListFavorites(ctx)
+//	c.RemoveFavorite(ctx, fileID)
 package pcloud

--- a/example_test.go
+++ b/example_test.go
@@ -263,3 +263,78 @@ func ExampleClient_RevertRevision() {
 
 	fmt.Printf("Reverted to revision, new size: %d\n", meta.Size)
 }
+
+func ExampleClient_ListTrash() {
+	ctx := context.Background()
+	c := pcloud.NewClient(pcloud.BaseURLUS)
+	c.Login(ctx, "user@example.com", "password")
+	defer c.Logout(ctx)
+
+	items, err := c.ListTrash(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, item := range items {
+		fmt.Printf("Trashed: %s\n", item.Name)
+	}
+}
+
+func ExampleClient_EmptyTrash() {
+	ctx := context.Background()
+	c := pcloud.NewClient(pcloud.BaseURLUS)
+	c.Login(ctx, "user@example.com", "password")
+	defer c.Logout(ctx)
+
+	if err := c.EmptyTrash(ctx); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("trash emptied")
+}
+
+func ExampleClient_Search() {
+	ctx := context.Background()
+	c := pcloud.NewClient(pcloud.BaseURLUS)
+	c.Login(ctx, "user@example.com", "password")
+	defer c.Logout(ctx)
+
+	results, err := c.Search(ctx, "report", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, item := range results {
+		fmt.Printf("Found: %s (%d bytes)\n", item.Name, item.Size)
+	}
+}
+
+func ExampleClient_GetThumbnail() {
+	ctx := context.Background()
+	c := pcloud.NewClient(pcloud.BaseURLUS)
+	c.Login(ctx, "user@example.com", "password")
+	defer c.Logout(ctx)
+
+	link, err := c.GetThumbnail(ctx, 12345, 200, 200, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Thumbnail URL: %s\n", link.URL())
+}
+
+func ExampleClient_ListFavorites() {
+	ctx := context.Background()
+	c := pcloud.NewClient(pcloud.BaseURLUS)
+	c.Login(ctx, "user@example.com", "password")
+	defer c.Logout(ctx)
+
+	favorites, err := c.ListFavorites(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, item := range favorites {
+		fmt.Printf("Favorite: %s\n", item.Name)
+	}
+}

--- a/favorites.go
+++ b/favorites.go
@@ -1,0 +1,51 @@
+package pcloud
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+)
+
+type favoritesResponse struct {
+	Error
+	Items []Metadata `json:"items"`
+}
+
+// ListFavorites returns all files and folders marked as favorites.
+func (c *Client) ListFavorites(ctx context.Context) ([]Metadata, error) {
+	var resp favoritesResponse
+	if err := c.do(ctx, "getfavourites", url.Values{}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+}
+
+func (c *Client) addFavorite(ctx context.Context, params url.Values) error {
+	var resp Error
+	return c.do(ctx, "addfavourite", params, &resp)
+}
+
+// AddFavorite marks a file as a favorite by numeric ID.
+func (c *Client) AddFavorite(ctx context.Context, fileID uint64) error {
+	return c.addFavorite(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+}
+
+// AddFavoriteByPath marks a file as a favorite by path.
+func (c *Client) AddFavoriteByPath(ctx context.Context, path string) error {
+	return c.addFavorite(ctx, url.Values{"path": {path}})
+}
+
+func (c *Client) removeFavorite(ctx context.Context, params url.Values) error {
+	var resp Error
+	return c.do(ctx, "removefavourite", params, &resp)
+}
+
+// RemoveFavorite removes a file from favorites by numeric ID.
+func (c *Client) RemoveFavorite(ctx context.Context, fileID uint64) error {
+	return c.removeFavorite(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+}
+
+// RemoveFavoriteByPath removes a file from favorites by path.
+func (c *Client) RemoveFavoriteByPath(ctx context.Context, path string) error {
+	return c.removeFavorite(ctx, url.Values{"path": {path}})
+}

--- a/favorites_test.go
+++ b/favorites_test.go
@@ -1,0 +1,91 @@
+package pcloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestListFavorites(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/getfavourites" {
+			http.Error(w, "wrong endpoint", http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(favoritesResponse{
+			Items: []Metadata{
+				{Name: "fav1.jpg", FileID: 10},
+				{Name: "fav2.pdf", FileID: 20},
+			},
+		})
+	})
+
+	items, err := c.ListFavorites(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("want 2 favorites, got %d", len(items))
+	}
+}
+
+func TestAddFavorite(t *testing.T) {
+	var gotFileID string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotFileID = r.URL.Query().Get("fileid")
+		json.NewEncoder(w).Encode(Error{Result: 0})
+	})
+
+	if err := c.AddFavorite(context.Background(), 55); err != nil {
+		t.Fatal(err)
+	}
+	if gotFileID != "55" {
+		t.Fatalf("want fileid=55, got %q", gotFileID)
+	}
+}
+
+func TestAddFavoriteByPath(t *testing.T) {
+	var gotPath string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Query().Get("path")
+		json.NewEncoder(w).Encode(Error{Result: 0})
+	})
+
+	if err := c.AddFavoriteByPath(context.Background(), "/docs/fav.pdf"); err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/docs/fav.pdf" {
+		t.Fatalf("want path=/docs/fav.pdf, got %q", gotPath)
+	}
+}
+
+func TestRemoveFavorite(t *testing.T) {
+	var gotFileID string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotFileID = r.URL.Query().Get("fileid")
+		json.NewEncoder(w).Encode(Error{Result: 0})
+	})
+
+	if err := c.RemoveFavorite(context.Background(), 77); err != nil {
+		t.Fatal(err)
+	}
+	if gotFileID != "77" {
+		t.Fatalf("want fileid=77, got %q", gotFileID)
+	}
+}
+
+func TestRemoveFavoriteByPath(t *testing.T) {
+	var gotPath string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Query().Get("path")
+		json.NewEncoder(w).Encode(Error{Result: 0})
+	})
+
+	if err := c.RemoveFavoriteByPath(context.Background(), "/docs/unfav.pdf"); err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/docs/unfav.pdf" {
+		t.Fatalf("want path=/docs/unfav.pdf, got %q", gotPath)
+	}
+}

--- a/file.go
+++ b/file.go
@@ -17,8 +17,11 @@ type uploadResponse struct {
 	Metadata []Metadata `json:"metadata"`
 }
 
+// ProgressFunc is called during upload or download with cumulative bytes transferred and total size.
+// Total may be -1 if the size is unknown.
 type ProgressFunc func(transferred, total int64)
 
+// UploadOpts controls optional parameters for file uploads.
 type UploadOpts struct {
 	NoPartial      bool
 	RenameIfExists bool
@@ -27,6 +30,7 @@ type UploadOpts struct {
 	OnProgress     ProgressFunc
 }
 
+// DownloadOpts controls optional parameters for file downloads.
 type DownloadOpts struct {
 	OnProgress ProgressFunc
 }
@@ -151,6 +155,7 @@ func (c *Client) upload(ctx context.Context, params url.Values, filename string,
 	return &resp.Metadata[0], nil
 }
 
+// Upload uploads content to folderID as filename.
 func (c *Client) Upload(ctx context.Context, folderID uint64, filename string, content io.Reader, opts *UploadOpts) (*Metadata, error) {
 	params := url.Values{
 		"folderid": {strconv.FormatUint(folderID, 10)},
@@ -159,6 +164,7 @@ func (c *Client) Upload(ctx context.Context, folderID uint64, filename string, c
 	return c.upload(ctx, params, filename, content, opts)
 }
 
+// UploadByPath uploads content to the folder at path as filename.
 func (c *Client) UploadByPath(ctx context.Context, path, filename string, content io.Reader, opts *UploadOpts) (*Metadata, error) {
 	params := url.Values{
 		"path":     {path},
@@ -167,6 +173,8 @@ func (c *Client) UploadByPath(ctx context.Context, path, filename string, conten
 	return c.upload(ctx, params, filename, content, opts)
 }
 
+// Download downloads a file by ID and returns the response body.
+// The caller must close the returned ReadCloser.
 func (c *Client) Download(ctx context.Context, fileID uint64, opts *DownloadOpts) (io.ReadCloser, error) {
 	link, err := c.GetFileLink(ctx, fileID)
 	if err != nil {
@@ -175,6 +183,8 @@ func (c *Client) Download(ctx context.Context, fileID uint64, opts *DownloadOpts
 	return c.downloadFromLink(ctx, link, opts)
 }
 
+// DownloadByPath downloads a file by path and returns the response body.
+// The caller must close the returned ReadCloser.
 func (c *Client) DownloadByPath(ctx context.Context, path string, opts *DownloadOpts) (io.ReadCloser, error) {
 	link, err := c.GetFileLinkByPath(ctx, path)
 	if err != nil {
@@ -216,10 +226,12 @@ func (c *Client) stat(ctx context.Context, params url.Values) (*Metadata, error)
 	return &resp.Metadata, nil
 }
 
+// Stat returns metadata for a file identified by numeric ID.
 func (c *Client) Stat(ctx context.Context, fileID uint64) (*Metadata, error) {
 	return c.stat(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
 }
 
+// StatByPath returns metadata for a file identified by path.
 func (c *Client) StatByPath(ctx context.Context, path string) (*Metadata, error) {
 	return c.stat(ctx, url.Values{"path": {path}})
 }
@@ -229,14 +241,17 @@ func (c *Client) deleteFile(ctx context.Context, params url.Values) error {
 	return c.do(ctx, "deletefile", params, &resp)
 }
 
+// DeleteFile deletes a file by numeric ID.
 func (c *Client) DeleteFile(ctx context.Context, fileID uint64) error {
 	return c.deleteFile(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
 }
 
+// DeleteFileByPath deletes a file by path.
 func (c *Client) DeleteFileByPath(ctx context.Context, path string) error {
 	return c.deleteFile(ctx, url.Values{"path": {path}})
 }
 
+// RenameFile renames a file in-place.
 func (c *Client) RenameFile(ctx context.Context, fileID uint64, newName string) (*Metadata, error) {
 	params := url.Values{
 		"fileid": {strconv.FormatUint(fileID, 10)},
@@ -250,6 +265,7 @@ func (c *Client) RenameFile(ctx context.Context, fileID uint64, newName string) 
 	return &resp.Metadata, nil
 }
 
+// MoveFile moves a file to a different folder and optionally renames it.
 func (c *Client) MoveFile(ctx context.Context, fileID, toFolderID uint64, name string) (*Metadata, error) {
 	params := url.Values{
 		"fileid":     {strconv.FormatUint(fileID, 10)},
@@ -264,6 +280,7 @@ func (c *Client) MoveFile(ctx context.Context, fileID, toFolderID uint64, name s
 	return &resp.Metadata, nil
 }
 
+// CopyFile copies a file into toFolderID.
 func (c *Client) CopyFile(ctx context.Context, fileID, toFolderID uint64) (*Metadata, error) {
 	params := url.Values{
 		"fileid":     {strconv.FormatUint(fileID, 10)},

--- a/file.go
+++ b/file.go
@@ -149,6 +149,7 @@ func (c *Client) upload(ctx context.Context, params url.Values, filename string,
 
 	var resp uploadResponse
 	if err := c.doPost(ctx, "uploadfile", params, pr, writer.FormDataContentType(), &resp); err != nil {
+		<-errCh
 		return nil, err
 	}
 	if err := <-errCh; err != nil {

--- a/file.go
+++ b/file.go
@@ -1,7 +1,6 @@
 package pcloud
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -124,21 +123,35 @@ func (c *Client) upload(ctx context.Context, params url.Values, filename string,
 		}
 	}
 
-	var body bytes.Buffer
-	writer := multipart.NewWriter(&body)
-	part, err := writer.CreateFormFile("file", filename)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := io.Copy(part, readContent); err != nil {
-		return nil, err
-	}
-	if err := writer.Close(); err != nil {
-		return nil, err
-	}
+	pr, pw := io.Pipe()
+	writer := multipart.NewWriter(pw)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		part, err := writer.CreateFormFile("file", filename)
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			errCh <- err
+			return
+		}
+		if _, err := io.Copy(part, readContent); err != nil {
+			_ = pw.CloseWithError(err)
+			errCh <- err
+			return
+		}
+		if err := writer.Close(); err != nil {
+			_ = pw.CloseWithError(err)
+			errCh <- err
+			return
+		}
+		_ = pw.Close()
+	}()
 
 	var resp uploadResponse
-	if err := c.doPost(ctx, "uploadfile", params, &body, writer.FormDataContentType(), &resp); err != nil {
+	if err := c.doPost(ctx, "uploadfile", params, pr, writer.FormDataContentType(), &resp); err != nil {
+		return nil, err
+	}
+	if err := <-errCh; err != nil {
 		return nil, err
 	}
 	if len(resp.Metadata) == 0 {

--- a/file.go
+++ b/file.go
@@ -149,7 +149,7 @@ func (c *Client) upload(ctx context.Context, params url.Values, filename string,
 
 	var resp uploadResponse
 	if err := c.doPost(ctx, "uploadfile", params, pr, writer.FormDataContentType(), &resp); err != nil {
-		<-errCh
+		_ = pr.CloseWithError(err)
 		return nil, err
 	}
 	if err := <-errCh; err != nil {

--- a/file.go
+++ b/file.go
@@ -11,11 +11,6 @@ import (
 	"strconv"
 )
 
-type fileResponse struct {
-	Error
-	Metadata Metadata `json:"metadata"`
-}
-
 type uploadResponse struct {
 	Error
 	FileIDs  []uint64   `json:"fileids"`
@@ -37,15 +32,14 @@ type DownloadOpts struct {
 }
 
 type progressReader struct {
-	reader     io.Reader
-	closer     io.Closer
+	rc         io.ReadCloser
 	total      int64
 	read       int64
 	onProgress ProgressFunc
 }
 
 func (pr *progressReader) Read(p []byte) (int, error) {
-	n, err := pr.reader.Read(p)
+	n, err := pr.rc.Read(p)
 	if n > 0 && pr.onProgress != nil {
 		pr.read += int64(n)
 		pr.onProgress(pr.read, pr.total)
@@ -54,10 +48,7 @@ func (pr *progressReader) Read(p []byte) (int, error) {
 }
 
 func (pr *progressReader) Close() error {
-	if pr.closer != nil {
-		return pr.closer.Close()
-	}
-	return nil
+	return pr.rc.Close()
 }
 
 func getContentSize(r io.Reader) (int64, error) {
@@ -116,8 +107,7 @@ func (c *Client) upload(ctx context.Context, params url.Values, filename string,
 	readContent := content
 	if opts != nil && opts.OnProgress != nil && contentSize > 0 {
 		readContent = &progressReader{
-			reader:     content,
-			closer:     nil,
+			rc:         io.NopCloser(content),
 			total:      contentSize,
 			onProgress: opts.OnProgress,
 		}
@@ -210,8 +200,7 @@ func (c *Client) downloadFromLink(ctx context.Context, link *FileLink, opts *Dow
 
 	if opts != nil && opts.OnProgress != nil {
 		return &progressReader{
-			reader:     resp.Body,
-			closer:     resp.Body,
+			rc:         resp.Body,
 			total:      resp.ContentLength,
 			onProgress: opts.OnProgress,
 		}, nil
@@ -219,46 +208,33 @@ func (c *Client) downloadFromLink(ctx context.Context, link *FileLink, opts *Dow
 	return resp.Body, nil
 }
 
-func (c *Client) Stat(ctx context.Context, fileID uint64) (*Metadata, error) {
-	params := url.Values{
-		"fileid": {strconv.FormatUint(fileID, 10)},
-	}
-
-	var resp fileResponse
+func (c *Client) stat(ctx context.Context, params url.Values) (*Metadata, error) {
+	var resp metadataResponse
 	if err := c.do(ctx, "stat", params, &resp); err != nil {
 		return nil, err
 	}
 	return &resp.Metadata, nil
+}
+
+func (c *Client) Stat(ctx context.Context, fileID uint64) (*Metadata, error) {
+	return c.stat(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
 }
 
 func (c *Client) StatByPath(ctx context.Context, path string) (*Metadata, error) {
-	params := url.Values{
-		"path": {path},
-	}
+	return c.stat(ctx, url.Values{"path": {path}})
+}
 
-	var resp fileResponse
-	if err := c.do(ctx, "stat", params, &resp); err != nil {
-		return nil, err
-	}
-	return &resp.Metadata, nil
+func (c *Client) deleteFile(ctx context.Context, params url.Values) error {
+	var resp Error
+	return c.do(ctx, "deletefile", params, &resp)
 }
 
 func (c *Client) DeleteFile(ctx context.Context, fileID uint64) error {
-	params := url.Values{
-		"fileid": {strconv.FormatUint(fileID, 10)},
-	}
-
-	var resp Error
-	return c.do(ctx, "deletefile", params, &resp)
+	return c.deleteFile(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
 }
 
 func (c *Client) DeleteFileByPath(ctx context.Context, path string) error {
-	params := url.Values{
-		"path": {path},
-	}
-
-	var resp Error
-	return c.do(ctx, "deletefile", params, &resp)
+	return c.deleteFile(ctx, url.Values{"path": {path}})
 }
 
 func (c *Client) RenameFile(ctx context.Context, fileID uint64, newName string) (*Metadata, error) {
@@ -267,7 +243,7 @@ func (c *Client) RenameFile(ctx context.Context, fileID uint64, newName string) 
 		"toname": {newName},
 	}
 
-	var resp fileResponse
+	var resp metadataResponse
 	if err := c.do(ctx, "renamefile", params, &resp); err != nil {
 		return nil, err
 	}
@@ -281,7 +257,7 @@ func (c *Client) MoveFile(ctx context.Context, fileID, toFolderID uint64, name s
 		"toname":     {name},
 	}
 
-	var resp fileResponse
+	var resp metadataResponse
 	if err := c.do(ctx, "renamefile", params, &resp); err != nil {
 		return nil, err
 	}
@@ -294,7 +270,7 @@ func (c *Client) CopyFile(ctx context.Context, fileID, toFolderID uint64) (*Meta
 		"tofolderid": {strconv.FormatUint(toFolderID, 10)},
 	}
 
-	var resp fileResponse
+	var resp metadataResponse
 	if err := c.do(ctx, "copyfile", params, &resp); err != nil {
 		return nil, err
 	}

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,127 @@
+package pcloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestStat(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("fileid") != "123" {
+			http.Error(w, "bad fileid", http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{Name: "photo.jpg", FileID: 123},
+		})
+	})
+
+	meta, err := c.Stat(context.Background(), 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Name != "photo.jpg" {
+		t.Fatalf("want photo.jpg, got %q", meta.Name)
+	}
+}
+
+func TestStatByPath(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("path") != "/photo.jpg" {
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{Name: "photo.jpg"},
+		})
+	})
+
+	meta, err := c.StatByPath(context.Background(), "/photo.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Name != "photo.jpg" {
+		t.Fatalf("want photo.jpg, got %q", meta.Name)
+	}
+}
+
+func TestDeleteFile(t *testing.T) {
+	var gotFileID string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotFileID = r.URL.Query().Get("fileid")
+		json.NewEncoder(w).Encode(Error{Result: 0})
+	})
+
+	if err := c.DeleteFile(context.Background(), 55); err != nil {
+		t.Fatal(err)
+	}
+	if gotFileID != "55" {
+		t.Fatalf("want fileid=55, got %q", gotFileID)
+	}
+}
+
+func TestDeleteFileByPath(t *testing.T) {
+	var gotPath string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Query().Get("path")
+		json.NewEncoder(w).Encode(Error{Result: 0})
+	})
+
+	if err := c.DeleteFileByPath(context.Background(), "/old.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/old.txt" {
+		t.Fatalf("want path=/old.txt, got %q", gotPath)
+	}
+}
+
+func TestUpload(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(uploadResponse{
+			Metadata: []Metadata{{Name: "hello.txt", FileID: 77}},
+		})
+	})
+
+	content := bytes.NewReader([]byte("hello"))
+	meta, err := c.Upload(context.Background(), 0, "hello.txt", content, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.FileID != 77 {
+		t.Fatalf("want fileid=77, got %d", meta.FileID)
+	}
+}
+
+func TestProgressReaderCumulative(t *testing.T) {
+	var calls []int64
+	pr := &progressReader{
+		rc:    io.NopCloser(strings.NewReader("0123456789")),
+		total: 10,
+		onProgress: func(transferred, total int64) {
+			calls = append(calls, transferred)
+		},
+	}
+
+	buf := make([]byte, 5)
+	if _, err := pr.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pr.Read(buf); err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+
+	if len(calls) < 2 {
+		t.Fatalf("expected 2 progress callbacks, got %d", len(calls))
+	}
+	if calls[0] != 5 {
+		t.Fatalf("first callback: want 5, got %d", calls[0])
+	}
+	if calls[1] != 10 {
+		t.Fatalf("second callback: want 10, got %d", calls[1])
+	}
+}

--- a/file_test.go
+++ b/file_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -111,7 +112,7 @@ func TestProgressReaderCumulative(t *testing.T) {
 	if _, err := pr.Read(buf); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := pr.Read(buf); err != nil && err != io.EOF {
+	if _, err := pr.Read(buf); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatal(err)
 	}
 

--- a/folder.go
+++ b/folder.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 )
 
+// ListFolderOpts controls optional parameters for listing folder contents.
 type ListFolderOpts struct {
 	Recursive   bool
 	ShowDeleted bool
@@ -41,10 +42,12 @@ func (c *Client) listFolder(ctx context.Context, params url.Values, opts *ListFo
 	return &resp.Metadata, nil
 }
 
+// ListFolder returns the contents of a folder identified by numeric ID.
 func (c *Client) ListFolder(ctx context.Context, folderID uint64, opts *ListFolderOpts) (*Metadata, error) {
 	return c.listFolder(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}}, opts)
 }
 
+// ListFolderByPath returns the contents of a folder identified by path.
 func (c *Client) ListFolderByPath(ctx context.Context, path string, opts *ListFolderOpts) (*Metadata, error) {
 	return c.listFolder(ctx, url.Values{"path": {path}}, opts)
 }
@@ -57,10 +60,12 @@ func (c *Client) statFolder(ctx context.Context, params url.Values) (*Metadata, 
 	return &resp.Metadata, nil
 }
 
+// StatFolder returns metadata for a folder identified by numeric ID.
 func (c *Client) StatFolder(ctx context.Context, folderID uint64) (*Metadata, error) {
 	return c.statFolder(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}})
 }
 
+// StatFolderByPath returns metadata for a folder identified by path.
 func (c *Client) StatFolderByPath(ctx context.Context, path string) (*Metadata, error) {
 	return c.statFolder(ctx, url.Values{"path": {path}})
 }
@@ -73,6 +78,7 @@ func (c *Client) createFolder(ctx context.Context, params url.Values) (*Metadata
 	return &resp.Metadata, nil
 }
 
+// CreateFolder creates a new folder inside parentID with the given name.
 func (c *Client) CreateFolder(ctx context.Context, parentID uint64, name string) (*Metadata, error) {
 	return c.createFolder(ctx, url.Values{
 		"folderid": {strconv.FormatUint(parentID, 10)},
@@ -80,10 +86,12 @@ func (c *Client) CreateFolder(ctx context.Context, parentID uint64, name string)
 	})
 }
 
+// CreateFolderByPath creates a folder at the given absolute path.
 func (c *Client) CreateFolderByPath(ctx context.Context, path string) (*Metadata, error) {
 	return c.createFolder(ctx, url.Values{"path": {path}})
 }
 
+// CreateFolderIfNotExists creates a folder only if it does not already exist.
 func (c *Client) CreateFolderIfNotExists(ctx context.Context, parentID uint64, name string) (*Metadata, error) {
 	params := url.Values{
 		"folderid": {strconv.FormatUint(parentID, 10)},
@@ -97,6 +105,7 @@ func (c *Client) CreateFolderIfNotExists(ctx context.Context, parentID uint64, n
 	return &resp.Metadata, nil
 }
 
+// RenameFolder renames a folder in-place.
 func (c *Client) RenameFolder(ctx context.Context, folderID uint64, newName string) (*Metadata, error) {
 	params := url.Values{
 		"folderid": {strconv.FormatUint(folderID, 10)},
@@ -110,6 +119,7 @@ func (c *Client) RenameFolder(ctx context.Context, folderID uint64, newName stri
 	return &resp.Metadata, nil
 }
 
+// MoveFolder moves a folder to a different parent and optionally renames it.
 func (c *Client) MoveFolder(ctx context.Context, folderID, toFolderID uint64, name string) (*Metadata, error) {
 	params := url.Values{
 		"folderid":   {strconv.FormatUint(folderID, 10)},
@@ -124,6 +134,7 @@ func (c *Client) MoveFolder(ctx context.Context, folderID, toFolderID uint64, na
 	return &resp.Metadata, nil
 }
 
+// CopyFolder copies a folder into toFolderID.
 func (c *Client) CopyFolder(ctx context.Context, folderID, toFolderID uint64) (*Metadata, error) {
 	params := url.Values{
 		"folderid":   {strconv.FormatUint(folderID, 10)},
@@ -137,6 +148,7 @@ func (c *Client) CopyFolder(ctx context.Context, folderID, toFolderID uint64) (*
 	return &resp.Metadata, nil
 }
 
+// DeleteFolder deletes an empty folder.
 func (c *Client) DeleteFolder(ctx context.Context, folderID uint64) error {
 	params := url.Values{
 		"folderid": {strconv.FormatUint(folderID, 10)},
@@ -146,6 +158,7 @@ func (c *Client) DeleteFolder(ctx context.Context, folderID uint64) error {
 	return c.do(ctx, "deletefolder", params, &resp)
 }
 
+// DeleteFolderRecursive deletes a folder and all its contents.
 func (c *Client) DeleteFolderRecursive(ctx context.Context, folderID uint64) error {
 	params := url.Values{
 		"folderid": {strconv.FormatUint(folderID, 10)},
@@ -181,6 +194,8 @@ func walkContents(ctx context.Context, contents []Metadata, yield func(Metadata,
 	walk(contents)
 }
 
+// Walk returns an iterator that yields every file and folder under folderID recursively.
+// The caller may break early. Context cancellation stops iteration.
 func (c *Client) Walk(ctx context.Context, folderID uint64) iter.Seq2[Metadata, error] {
 	return func(yield func(Metadata, error) bool) {
 		folder, err := c.ListFolder(ctx, folderID, &ListFolderOpts{Recursive: true})
@@ -192,6 +207,7 @@ func (c *Client) Walk(ctx context.Context, folderID uint64) iter.Seq2[Metadata, 
 	}
 }
 
+// WalkByPath returns an iterator that yields every file and folder under path recursively.
 func (c *Client) WalkByPath(ctx context.Context, path string) iter.Seq2[Metadata, error] {
 	return func(yield func(Metadata, error) bool) {
 		folder, err := c.ListFolderByPath(ctx, path, &ListFolderOpts{Recursive: true})

--- a/folder.go
+++ b/folder.go
@@ -171,10 +171,18 @@ func (c *Client) DeleteFolderRecursive(ctx context.Context, folderID uint64) err
 	return c.do(ctx, "deletefolderrecursive", params, &resp)
 }
 
-func walkContents(contents []Metadata, yield func(Metadata, error) bool) {
+func walkContents(ctx context.Context, contents []Metadata, yield func(Metadata, error) bool) {
 	var walk func(items []Metadata) bool
 	walk = func(items []Metadata) bool {
+		if err := ctx.Err(); err != nil {
+			yield(Metadata{}, err)
+			return false
+		}
 		for _, item := range items {
+			if err := ctx.Err(); err != nil {
+				yield(Metadata{}, err)
+				return false
+			}
 			if !yield(item, nil) {
 				return false
 			}
@@ -196,7 +204,7 @@ func (c *Client) Walk(ctx context.Context, folderID uint64) iter.Seq2[Metadata, 
 			yield(Metadata{}, err)
 			return
 		}
-		walkContents(folder.Contents, yield)
+		walkContents(ctx, folder.Contents, yield)
 	}
 }
 
@@ -207,6 +215,6 @@ func (c *Client) WalkByPath(ctx context.Context, path string) iter.Seq2[Metadata
 			yield(Metadata{}, err)
 			return
 		}
-		walkContents(folder.Contents, yield)
+		walkContents(ctx, folder.Contents, yield)
 	}
 }

--- a/folder.go
+++ b/folder.go
@@ -7,11 +7,6 @@ import (
 	"strconv"
 )
 
-type folderResponse struct {
-	Error
-	Metadata Metadata `json:"metadata"`
-}
-
 type ListFolderOpts struct {
 	Recursive   bool
 	ShowDeleted bool
@@ -37,67 +32,56 @@ func applyListFolderOpts(params url.Values, opts *ListFolderOpts) {
 	}
 }
 
-func (c *Client) ListFolder(ctx context.Context, folderID uint64, opts *ListFolderOpts) (*Metadata, error) {
-	params := url.Values{
-		"folderid": {strconv.FormatUint(folderID, 10)},
-	}
+func (c *Client) listFolder(ctx context.Context, params url.Values, opts *ListFolderOpts) (*Metadata, error) {
 	applyListFolderOpts(params, opts)
-
-	var resp folderResponse
+	var resp metadataResponse
 	if err := c.do(ctx, "listfolder", params, &resp); err != nil {
 		return nil, err
 	}
 	return &resp.Metadata, nil
+}
+
+func (c *Client) ListFolder(ctx context.Context, folderID uint64, opts *ListFolderOpts) (*Metadata, error) {
+	return c.listFolder(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}}, opts)
 }
 
 func (c *Client) ListFolderByPath(ctx context.Context, path string, opts *ListFolderOpts) (*Metadata, error) {
-	params := url.Values{
-		"path": {path},
-	}
-	applyListFolderOpts(params, opts)
-
-	var resp folderResponse
-	if err := c.do(ctx, "listfolder", params, &resp); err != nil {
-		return nil, err
-	}
-	return &resp.Metadata, nil
+	return c.listFolder(ctx, url.Values{"path": {path}}, opts)
 }
 
-func (c *Client) StatFolder(ctx context.Context, folderID uint64) (*Metadata, error) {
-	params := url.Values{
-		"folderid": {strconv.FormatUint(folderID, 10)},
-	}
-
-	var resp folderResponse
+func (c *Client) statFolder(ctx context.Context, params url.Values) (*Metadata, error) {
+	var resp metadataResponse
 	if err := c.do(ctx, "stat", params, &resp); err != nil {
 		return nil, err
 	}
 	return &resp.Metadata, nil
 }
 
-func (c *Client) CreateFolder(ctx context.Context, parentID uint64, name string) (*Metadata, error) {
-	params := url.Values{
-		"folderid": {strconv.FormatUint(parentID, 10)},
-		"name":     {name},
-	}
+func (c *Client) StatFolder(ctx context.Context, folderID uint64) (*Metadata, error) {
+	return c.statFolder(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}})
+}
 
-	var resp folderResponse
+func (c *Client) StatFolderByPath(ctx context.Context, path string) (*Metadata, error) {
+	return c.statFolder(ctx, url.Values{"path": {path}})
+}
+
+func (c *Client) createFolder(ctx context.Context, params url.Values) (*Metadata, error) {
+	var resp metadataResponse
 	if err := c.do(ctx, "createfolder", params, &resp); err != nil {
 		return nil, err
 	}
 	return &resp.Metadata, nil
 }
 
-func (c *Client) CreateFolderByPath(ctx context.Context, path string) (*Metadata, error) {
-	params := url.Values{
-		"path": {path},
-	}
+func (c *Client) CreateFolder(ctx context.Context, parentID uint64, name string) (*Metadata, error) {
+	return c.createFolder(ctx, url.Values{
+		"folderid": {strconv.FormatUint(parentID, 10)},
+		"name":     {name},
+	})
+}
 
-	var resp folderResponse
-	if err := c.do(ctx, "createfolder", params, &resp); err != nil {
-		return nil, err
-	}
-	return &resp.Metadata, nil
+func (c *Client) CreateFolderByPath(ctx context.Context, path string) (*Metadata, error) {
+	return c.createFolder(ctx, url.Values{"path": {path}})
 }
 
 func (c *Client) CreateFolderIfNotExists(ctx context.Context, parentID uint64, name string) (*Metadata, error) {
@@ -106,7 +90,7 @@ func (c *Client) CreateFolderIfNotExists(ctx context.Context, parentID uint64, n
 		"name":     {name},
 	}
 
-	var resp folderResponse
+	var resp metadataResponse
 	if err := c.do(ctx, "createfolderifnotexists", params, &resp); err != nil {
 		return nil, err
 	}
@@ -119,7 +103,7 @@ func (c *Client) RenameFolder(ctx context.Context, folderID uint64, newName stri
 		"toname":   {newName},
 	}
 
-	var resp folderResponse
+	var resp metadataResponse
 	if err := c.do(ctx, "renamefolder", params, &resp); err != nil {
 		return nil, err
 	}
@@ -133,7 +117,7 @@ func (c *Client) MoveFolder(ctx context.Context, folderID, toFolderID uint64, na
 		"toname":     {name},
 	}
 
-	var resp folderResponse
+	var resp metadataResponse
 	if err := c.do(ctx, "renamefolder", params, &resp); err != nil {
 		return nil, err
 	}
@@ -146,7 +130,7 @@ func (c *Client) CopyFolder(ctx context.Context, folderID, toFolderID uint64) (*
 		"tofolderid": {strconv.FormatUint(toFolderID, 10)},
 	}
 
-	var resp folderResponse
+	var resp metadataResponse
 	if err := c.do(ctx, "copyfolder", params, &resp); err != nil {
 		return nil, err
 	}

--- a/folder_test.go
+++ b/folder_test.go
@@ -1,0 +1,181 @@
+package pcloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestListFolder(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("folderid") != "0" {
+			http.Error(w, "bad folderid", http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{Name: "root", IsFolder: true},
+		})
+	})
+
+	meta, err := c.ListFolder(context.Background(), 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Name != "root" {
+		t.Fatalf("want root, got %q", meta.Name)
+	}
+}
+
+func TestListFolderByPath(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("path") != "/myfolder" {
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{Name: "myfolder", IsFolder: true},
+		})
+	})
+
+	meta, err := c.ListFolderByPath(context.Background(), "/myfolder", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Name != "myfolder" {
+		t.Fatalf("want myfolder, got %q", meta.Name)
+	}
+}
+
+func TestListFolderAPIError(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(metadataResponse{Error: Error{Result: 2005, Message: "not found"}})
+	})
+
+	_, err := c.ListFolder(context.Background(), 999, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestListFolderOpts(t *testing.T) {
+	var gotRecursive string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotRecursive = r.URL.Query().Get("recursive")
+		json.NewEncoder(w).Encode(metadataResponse{})
+	})
+
+	c.ListFolder(context.Background(), 0, &ListFolderOpts{Recursive: true})
+	if gotRecursive != "1" {
+		t.Fatalf("want recursive=1, got %q", gotRecursive)
+	}
+}
+
+func TestStatFolder(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{Name: "docs", IsFolder: true, FolderID: 42},
+		})
+	})
+
+	meta, err := c.StatFolder(context.Background(), 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.FolderID != 42 {
+		t.Fatalf("want folderid=42, got %d", meta.FolderID)
+	}
+}
+
+func TestStatFolderByPath(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("path") != "/docs" {
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{Name: "docs", IsFolder: true},
+		})
+	})
+
+	meta, err := c.StatFolderByPath(context.Background(), "/docs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Name != "docs" {
+		t.Fatalf("want docs, got %q", meta.Name)
+	}
+}
+
+func TestCreateFolder(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{Name: "new-dir", IsFolder: true, FolderID: 10},
+		})
+	})
+
+	meta, err := c.CreateFolder(context.Background(), 0, "new-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.FolderID != 10 {
+		t.Fatalf("want folderid=10, got %d", meta.FolderID)
+	}
+}
+
+func TestWalkYieldsContents(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{
+				IsFolder: true,
+				Contents: []Metadata{
+					{Name: "file1.txt", IsFolder: false},
+					{Name: "sub", IsFolder: true, Contents: []Metadata{
+						{Name: "file2.txt", IsFolder: false},
+					}},
+				},
+			},
+		})
+	})
+
+	var names []string
+	for item, err := range c.Walk(context.Background(), 0) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		names = append(names, item.Name)
+	}
+
+	if len(names) != 3 {
+		t.Fatalf("want 3 items, got %d: %v", len(names), names)
+	}
+}
+
+func TestWalkEarlyBreak(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{
+				IsFolder: true,
+				Contents: []Metadata{
+					{Name: "a"},
+					{Name: "b"},
+					{Name: "c"},
+				},
+			},
+		})
+	})
+
+	var count int
+	for _, err := range c.Walk(context.Background(), 0) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		count++
+		if count == 1 {
+			break
+		}
+	}
+	if count != 1 {
+		t.Fatalf("want 1, got %d", count)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yanmhlv/pcloud
 
-go 1.24.0
+go 1.25.0
 
 require golang.org/x/time v0.14.0
 

--- a/oauth.go
+++ b/oauth.go
@@ -7,11 +7,13 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// Endpoint is the OAuth2 endpoint for US-region pCloud accounts.
 var Endpoint = oauth2.Endpoint{
 	AuthURL:  BaseURLUS + "/oauth2_authorize",
 	TokenURL: BaseURLUS + "/oauth2_token",
 }
 
+// EndpointEU is the OAuth2 endpoint for EU-region pCloud accounts.
 var EndpointEU = oauth2.Endpoint{
 	AuthURL:  BaseURLEU + "/oauth2_authorize",
 	TokenURL: BaseURLEU + "/oauth2_token",
@@ -24,6 +26,7 @@ type exchangeResponse struct {
 	UserID      uint64 `json:"userid"`
 }
 
+// ExchangeCode exchanges an OAuth2 authorization code for an access token.
 func (c *Client) ExchangeCode(ctx context.Context, cfg *oauth2.Config, code string) (*oauth2.Token, error) {
 	params := url.Values{
 		"client_id":     {cfg.ClientID},

--- a/publink.go
+++ b/publink.go
@@ -23,7 +23,7 @@ type PublicLink struct {
 type PublicLinkOpts struct {
 	MaxDownloads uint64
 	MaxTraffic   uint64
-	ExpireTime   int64
+	ExpireAt     int64
 	ShortLink    bool
 }
 
@@ -42,20 +42,16 @@ func applyPublicLinkOpts(params url.Values, opts *PublicLinkOpts) {
 	if opts.MaxTraffic > 0 {
 		params.Set("maxtraffic", strconv.FormatUint(opts.MaxTraffic, 10))
 	}
-	if opts.ExpireTime > 0 {
-		params.Set("expire", strconv.FormatInt(opts.ExpireTime, 10))
+	if opts.ExpireAt > 0 {
+		params.Set("expire", strconv.FormatInt(opts.ExpireAt, 10))
 	}
 	if opts.ShortLink {
 		params.Set("shortlink", "1")
 	}
 }
 
-func (c *Client) CreateFilePublicLink(ctx context.Context, fileID uint64, opts *PublicLinkOpts) (*PublicLink, error) {
-	params := url.Values{
-		"fileid": {strconv.FormatUint(fileID, 10)},
-	}
+func (c *Client) createFilePublicLink(ctx context.Context, params url.Values, opts *PublicLinkOpts) (*PublicLink, error) {
 	applyPublicLinkOpts(params, opts)
-
 	var resp PublicLink
 	if err := c.do(ctx, "getfilepublink", params, &resp); err != nil {
 		return nil, err
@@ -63,43 +59,29 @@ func (c *Client) CreateFilePublicLink(ctx context.Context, fileID uint64, opts *
 	return &resp, nil
 }
 
-func (c *Client) CreateFilePublicLinkByPath(ctx context.Context, path string, opts *PublicLinkOpts) (*PublicLink, error) {
-	params := url.Values{
-		"path": {path},
-	}
-	applyPublicLinkOpts(params, opts)
+func (c *Client) CreateFilePublicLink(ctx context.Context, fileID uint64, opts *PublicLinkOpts) (*PublicLink, error) {
+	return c.createFilePublicLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, opts)
+}
 
+func (c *Client) CreateFilePublicLinkByPath(ctx context.Context, path string, opts *PublicLinkOpts) (*PublicLink, error) {
+	return c.createFilePublicLink(ctx, url.Values{"path": {path}}, opts)
+}
+
+func (c *Client) createFolderPublicLink(ctx context.Context, params url.Values, opts *PublicLinkOpts) (*PublicLink, error) {
+	applyPublicLinkOpts(params, opts)
 	var resp PublicLink
-	if err := c.do(ctx, "getfilepublink", params, &resp); err != nil {
+	if err := c.do(ctx, "getfolderpublink", params, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
 func (c *Client) CreateFolderPublicLink(ctx context.Context, folderID uint64, opts *PublicLinkOpts) (*PublicLink, error) {
-	params := url.Values{
-		"folderid": {strconv.FormatUint(folderID, 10)},
-	}
-	applyPublicLinkOpts(params, opts)
-
-	var resp PublicLink
-	if err := c.do(ctx, "getfolderpublink", params, &resp); err != nil {
-		return nil, err
-	}
-	return &resp, nil
+	return c.createFolderPublicLink(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}}, opts)
 }
 
 func (c *Client) CreateFolderPublicLinkByPath(ctx context.Context, path string, opts *PublicLinkOpts) (*PublicLink, error) {
-	params := url.Values{
-		"path": {path},
-	}
-	applyPublicLinkOpts(params, opts)
-
-	var resp PublicLink
-	if err := c.do(ctx, "getfolderpublink", params, &resp); err != nil {
-		return nil, err
-	}
-	return &resp, nil
+	return c.createFolderPublicLink(ctx, url.Values{"path": {path}}, opts)
 }
 
 func (c *Client) ListPublicLinks(ctx context.Context) ([]PublicLink, error) {

--- a/publink.go
+++ b/publink.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 )
 
+// PublicLink represents a shareable public link to a file or folder.
 type PublicLink struct {
 	Error
 	LinkID    uint64   `json:"linkid"`
@@ -20,6 +21,7 @@ type PublicLink struct {
 	ShortCode string   `json:"shortcode,omitempty"`
 }
 
+// PublicLinkOpts controls optional parameters for creating or updating public links.
 type PublicLinkOpts struct {
 	MaxDownloads uint64
 	MaxTraffic   uint64
@@ -59,10 +61,12 @@ func (c *Client) createFilePublicLink(ctx context.Context, params url.Values, op
 	return &resp, nil
 }
 
+// CreateFilePublicLink creates a public download link for a file by numeric ID.
 func (c *Client) CreateFilePublicLink(ctx context.Context, fileID uint64, opts *PublicLinkOpts) (*PublicLink, error) {
 	return c.createFilePublicLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, opts)
 }
 
+// CreateFilePublicLinkByPath creates a public download link for a file by path.
 func (c *Client) CreateFilePublicLinkByPath(ctx context.Context, path string, opts *PublicLinkOpts) (*PublicLink, error) {
 	return c.createFilePublicLink(ctx, url.Values{"path": {path}}, opts)
 }
@@ -76,14 +80,17 @@ func (c *Client) createFolderPublicLink(ctx context.Context, params url.Values, 
 	return &resp, nil
 }
 
+// CreateFolderPublicLink creates a public link for a folder by numeric ID.
 func (c *Client) CreateFolderPublicLink(ctx context.Context, folderID uint64, opts *PublicLinkOpts) (*PublicLink, error) {
 	return c.createFolderPublicLink(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}}, opts)
 }
 
+// CreateFolderPublicLinkByPath creates a public link for a folder by path.
 func (c *Client) CreateFolderPublicLinkByPath(ctx context.Context, path string, opts *PublicLinkOpts) (*PublicLink, error) {
 	return c.createFolderPublicLink(ctx, url.Values{"path": {path}}, opts)
 }
 
+// ListPublicLinks returns all public links created by the authenticated user.
 func (c *Client) ListPublicLinks(ctx context.Context) ([]PublicLink, error) {
 	var resp listPublicLinksResponse
 	if err := c.do(ctx, "listpublinks", url.Values{}, &resp); err != nil {
@@ -92,6 +99,7 @@ func (c *Client) ListPublicLinks(ctx context.Context) ([]PublicLink, error) {
 	return resp.PubLinks, nil
 }
 
+// DeletePublicLink removes a public link by its ID.
 func (c *Client) DeletePublicLink(ctx context.Context, linkID uint64) error {
 	params := url.Values{
 		"linkid": {strconv.FormatUint(linkID, 10)},
@@ -101,6 +109,7 @@ func (c *Client) DeletePublicLink(ctx context.Context, linkID uint64) error {
 	return c.do(ctx, "deletepublink", params, &resp)
 }
 
+// ChangePublicLink updates settings on an existing public link.
 func (c *Client) ChangePublicLink(ctx context.Context, linkID uint64, opts *PublicLinkOpts) (*PublicLink, error) {
 	params := url.Values{
 		"linkid": {strconv.FormatUint(linkID, 10)},
@@ -114,6 +123,7 @@ func (c *Client) ChangePublicLink(ctx context.Context, linkID uint64, opts *Publ
 	return &resp, nil
 }
 
+// GetPublicLinkInfo returns details about a public link identified by its short code.
 func (c *Client) GetPublicLinkInfo(ctx context.Context, code string) (*PublicLink, error) {
 	params := url.Values{
 		"code": {code},

--- a/publink_test.go
+++ b/publink_test.go
@@ -1,0 +1,94 @@
+package pcloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestCreateFilePublicLink(t *testing.T) {
+	var gotFileID string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotFileID = r.URL.Query().Get("fileid")
+		json.NewEncoder(w).Encode(PublicLink{LinkID: 7, Code: "abc"})
+	})
+
+	link, err := c.CreateFilePublicLink(context.Background(), 42, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link.LinkID != 7 {
+		t.Fatalf("want linkid=7, got %d", link.LinkID)
+	}
+	if gotFileID != "42" {
+		t.Fatalf("want fileid=42, got %q", gotFileID)
+	}
+}
+
+func TestCreateFilePublicLinkByPath(t *testing.T) {
+	var gotPath string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Query().Get("path")
+		json.NewEncoder(w).Encode(PublicLink{LinkID: 8})
+	})
+
+	_, err := c.CreateFilePublicLinkByPath(context.Background(), "/report.pdf", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/report.pdf" {
+		t.Fatalf("want path=/report.pdf, got %q", gotPath)
+	}
+}
+
+func TestCreateFilePublicLinkOpts(t *testing.T) {
+	var gotExpire, gotMaxDownloads string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotExpire = r.URL.Query().Get("expire")
+		gotMaxDownloads = r.URL.Query().Get("maxdownloads")
+		json.NewEncoder(w).Encode(PublicLink{})
+	})
+
+	c.CreateFilePublicLink(context.Background(), 1, &PublicLinkOpts{
+		ExpireAt:     1700000000,
+		MaxDownloads: 5,
+	})
+	if gotExpire != "1700000000" {
+		t.Fatalf("want expire=1700000000, got %q", gotExpire)
+	}
+	if gotMaxDownloads != "5" {
+		t.Fatalf("want maxdownloads=5, got %q", gotMaxDownloads)
+	}
+}
+
+func TestListPublicLinks(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(listPublicLinksResponse{
+			PubLinks: []PublicLink{{LinkID: 1}, {LinkID: 2}},
+		})
+	})
+
+	links, err := c.ListPublicLinks(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 2 {
+		t.Fatalf("want 2 links, got %d", len(links))
+	}
+}
+
+func TestDeletePublicLink(t *testing.T) {
+	var gotLinkID string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotLinkID = r.URL.Query().Get("linkid")
+		json.NewEncoder(w).Encode(Error{Result: 0})
+	})
+
+	if err := c.DeletePublicLink(context.Background(), 15); err != nil {
+		t.Fatal(err)
+	}
+	if gotLinkID != "15" {
+		t.Fatalf("want linkid=15, got %q", gotLinkID)
+	}
+}

--- a/revision.go
+++ b/revision.go
@@ -19,10 +19,12 @@ func (c *Client) listRevisions(ctx context.Context, params url.Values) ([]Revisi
 	return resp.Revisions, nil
 }
 
+// ListRevisions returns all revisions for a file identified by numeric ID.
 func (c *Client) ListRevisions(ctx context.Context, fileID uint64) ([]Revision, error) {
 	return c.listRevisions(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
 }
 
+// ListRevisionsByPath returns all revisions for a file identified by path.
 func (c *Client) ListRevisionsByPath(ctx context.Context, path string) ([]Revision, error) {
 	return c.listRevisions(ctx, url.Values{"path": {path}})
 }
@@ -35,6 +37,7 @@ func (c *Client) revertRevision(ctx context.Context, params url.Values) (*Metada
 	return &resp.Metadata, nil
 }
 
+// RevertRevision restores a file to a previous revision identified by file and revision IDs.
 func (c *Client) RevertRevision(ctx context.Context, fileID, revisionID uint64) (*Metadata, error) {
 	return c.revertRevision(ctx, url.Values{
 		"fileid":     {strconv.FormatUint(fileID, 10)},
@@ -42,6 +45,7 @@ func (c *Client) RevertRevision(ctx context.Context, fileID, revisionID uint64) 
 	})
 }
 
+// RevertRevisionByPath restores a file to a previous revision identified by path and revision ID.
 func (c *Client) RevertRevisionByPath(ctx context.Context, path string, revisionID uint64) (*Metadata, error) {
 	return c.revertRevision(ctx, url.Values{
 		"path":       {path},

--- a/revision.go
+++ b/revision.go
@@ -11,57 +11,40 @@ type revisionsResponse struct {
 	Revisions []Revision `json:"revisions"`
 }
 
-type revertResponse struct {
-	Error
-	Metadata Metadata `json:"metadata"`
+func (c *Client) listRevisions(ctx context.Context, params url.Values) ([]Revision, error) {
+	var resp revisionsResponse
+	if err := c.do(ctx, "listrevisions", params, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Revisions, nil
 }
 
 func (c *Client) ListRevisions(ctx context.Context, fileID uint64) ([]Revision, error) {
-	params := url.Values{
-		"fileid": {strconv.FormatUint(fileID, 10)},
-	}
-
-	var resp revisionsResponse
-	if err := c.do(ctx, "listrevisions", params, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Revisions, nil
+	return c.listRevisions(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
 }
 
 func (c *Client) ListRevisionsByPath(ctx context.Context, path string) ([]Revision, error) {
-	params := url.Values{
-		"path": {path},
-	}
+	return c.listRevisions(ctx, url.Values{"path": {path}})
+}
 
-	var resp revisionsResponse
-	if err := c.do(ctx, "listrevisions", params, &resp); err != nil {
+func (c *Client) revertRevision(ctx context.Context, params url.Values) (*Metadata, error) {
+	var resp metadataResponse
+	if err := c.do(ctx, "revertrevision", params, &resp); err != nil {
 		return nil, err
 	}
-	return resp.Revisions, nil
+	return &resp.Metadata, nil
 }
 
 func (c *Client) RevertRevision(ctx context.Context, fileID, revisionID uint64) (*Metadata, error) {
-	params := url.Values{
+	return c.revertRevision(ctx, url.Values{
 		"fileid":     {strconv.FormatUint(fileID, 10)},
 		"revisionid": {strconv.FormatUint(revisionID, 10)},
-	}
-
-	var resp revertResponse
-	if err := c.do(ctx, "revertrevision", params, &resp); err != nil {
-		return nil, err
-	}
-	return &resp.Metadata, nil
+	})
 }
 
 func (c *Client) RevertRevisionByPath(ctx context.Context, path string, revisionID uint64) (*Metadata, error) {
-	params := url.Values{
+	return c.revertRevision(ctx, url.Values{
 		"path":       {path},
 		"revisionid": {strconv.FormatUint(revisionID, 10)},
-	}
-
-	var resp revertResponse
-	if err := c.do(ctx, "revertrevision", params, &resp); err != nil {
-		return nil, err
-	}
-	return &resp.Metadata, nil
+	})
 }

--- a/revision_test.go
+++ b/revision_test.go
@@ -1,0 +1,72 @@
+package pcloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestListRevisions(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("fileid") != "20" {
+			http.Error(w, "bad fileid", http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(revisionsResponse{
+			Revisions: []Revision{
+				{RevisionID: 1, Size: 100},
+				{RevisionID: 2, Size: 200},
+			},
+		})
+	})
+
+	revs, err := c.ListRevisions(context.Background(), 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(revs) != 2 {
+		t.Fatalf("want 2 revisions, got %d", len(revs))
+	}
+}
+
+func TestListRevisionsByPath(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("path") != "/file.txt" {
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(revisionsResponse{
+			Revisions: []Revision{{RevisionID: 5, Size: 512}},
+		})
+	})
+
+	revs, err := c.ListRevisionsByPath(context.Background(), "/file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(revs) != 1 || revs[0].RevisionID != 5 {
+		t.Fatalf("unexpected revisions: %v", revs)
+	}
+}
+
+func TestRevertRevision(t *testing.T) {
+	var gotRevisionID string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotRevisionID = r.URL.Query().Get("revisionid")
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{Name: "file.txt"},
+		})
+	})
+
+	meta, err := c.RevertRevision(context.Background(), 20, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Name != "file.txt" {
+		t.Fatalf("want file.txt, got %q", meta.Name)
+	}
+	if gotRevisionID != "3" {
+		t.Fatalf("want revisionid=3, got %q", gotRevisionID)
+	}
+}

--- a/search.go
+++ b/search.go
@@ -1,0 +1,37 @@
+package pcloud
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+)
+
+// SearchOpts controls optional parameters for file searches.
+type SearchOpts struct {
+	FolderID  uint64
+	Recursive bool
+}
+
+type searchResponse struct {
+	Error
+	Items []Metadata `json:"items"`
+}
+
+// Search searches for files matching query. Pass nil opts for a global search.
+func (c *Client) Search(ctx context.Context, query string, opts *SearchOpts) ([]Metadata, error) {
+	params := url.Values{"query": {query}}
+	if opts != nil {
+		if opts.FolderID > 0 {
+			params.Set("folderid", strconv.FormatUint(opts.FolderID, 10))
+		}
+		if opts.Recursive {
+			params.Set("recursive", "1")
+		}
+	}
+
+	var resp searchResponse
+	if err := c.do(ctx, "searchfiles", params, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+}

--- a/search_test.go
+++ b/search_test.go
@@ -1,0 +1,60 @@
+package pcloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestSearch(t *testing.T) {
+	var gotQuery string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("query")
+		json.NewEncoder(w).Encode(searchResponse{
+			Items: []Metadata{
+				{Name: "report.pdf", FileID: 5},
+				{Name: "report-final.pdf", FileID: 6},
+			},
+		})
+	})
+
+	items, err := c.Search(context.Background(), "report", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("want 2 results, got %d", len(items))
+	}
+	if gotQuery != "report" {
+		t.Fatalf("want query=report, got %q", gotQuery)
+	}
+}
+
+func TestSearchWithOpts(t *testing.T) {
+	var gotFolderID, gotRecursive string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotFolderID = r.URL.Query().Get("folderid")
+		gotRecursive = r.URL.Query().Get("recursive")
+		json.NewEncoder(w).Encode(searchResponse{})
+	})
+
+	c.Search(context.Background(), "img", &SearchOpts{FolderID: 10, Recursive: true})
+	if gotFolderID != "10" {
+		t.Fatalf("want folderid=10, got %q", gotFolderID)
+	}
+	if gotRecursive != "1" {
+		t.Fatalf("want recursive=1, got %q", gotRecursive)
+	}
+}
+
+func TestSearchAPIError(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(searchResponse{Error: Error{Result: 2003, Message: "access denied"}})
+	})
+
+	_, err := c.Search(context.Background(), "secret", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/sharing.go
+++ b/sharing.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 )
 
+// SharePermissions defines the access rights granted in a folder share.
 type SharePermissions struct {
 	CanRead   bool
 	CanCreate bool
@@ -13,6 +14,7 @@ type SharePermissions struct {
 	CanDelete bool
 }
 
+// Share represents a folder sharing record, including both active shares and pending requests.
 type Share struct {
 	Error
 	ShareID         uint64 `json:"shareid"`
@@ -32,6 +34,7 @@ type Share struct {
 	IncomingRequest bool   `json:"incoming,omitempty"`
 }
 
+// ShareOpts controls optional parameters for sharing a folder.
 type ShareOpts struct {
 	Message string
 }
@@ -65,6 +68,7 @@ func applyPermissions(params url.Values, perms SharePermissions) {
 	}
 }
 
+// ShareFolder shares a folder identified by numeric ID with another user by email.
 func (c *Client) ShareFolder(ctx context.Context, folderID uint64, email string, perms SharePermissions, opts *ShareOpts) (*Share, error) {
 	params := url.Values{
 		"folderid": {strconv.FormatUint(folderID, 10)},
@@ -73,6 +77,7 @@ func (c *Client) ShareFolder(ctx context.Context, folderID uint64, email string,
 	return c.shareFolder(ctx, params, perms, opts)
 }
 
+// ShareFolderByPath shares a folder identified by path with another user by email.
 func (c *Client) ShareFolderByPath(ctx context.Context, path string, email string, perms SharePermissions, opts *ShareOpts) (*Share, error) {
 	params := url.Values{
 		"path": {path},
@@ -94,6 +99,7 @@ func (c *Client) shareFolder(ctx context.Context, params url.Values, perms Share
 	return &resp, nil
 }
 
+// ListShares returns active shares and pending share requests for the authenticated user.
 func (c *Client) ListShares(ctx context.Context) ([]Share, []Share, error) {
 	var resp listSharesResponse
 	if err := c.do(ctx, "listshares", url.Values{}, &resp); err != nil {
@@ -102,6 +108,7 @@ func (c *Client) ListShares(ctx context.Context) ([]Share, []Share, error) {
 	return resp.Shares, resp.Requests, nil
 }
 
+// AcceptShare accepts an incoming share request by its ID.
 func (c *Client) AcceptShare(ctx context.Context, shareRequestID uint64) error {
 	params := url.Values{
 		"sharerequestid": {strconv.FormatUint(shareRequestID, 10)},
@@ -111,6 +118,7 @@ func (c *Client) AcceptShare(ctx context.Context, shareRequestID uint64) error {
 	return c.do(ctx, "acceptshare", params, &resp)
 }
 
+// DeclineShare declines an incoming share request by its ID.
 func (c *Client) DeclineShare(ctx context.Context, shareRequestID uint64) error {
 	params := url.Values{
 		"sharerequestid": {strconv.FormatUint(shareRequestID, 10)},
@@ -120,6 +128,7 @@ func (c *Client) DeclineShare(ctx context.Context, shareRequestID uint64) error 
 	return c.do(ctx, "declineshare", params, &resp)
 }
 
+// RemoveShare removes an active share by its ID.
 func (c *Client) RemoveShare(ctx context.Context, shareID uint64) error {
 	params := url.Values{
 		"shareid": {strconv.FormatUint(shareID, 10)},
@@ -129,6 +138,7 @@ func (c *Client) RemoveShare(ctx context.Context, shareID uint64) error {
 	return c.do(ctx, "removeshare", params, &resp)
 }
 
+// CancelShareRequest cancels an outgoing share request by its ID.
 func (c *Client) CancelShareRequest(ctx context.Context, shareRequestID uint64) error {
 	params := url.Values{
 		"sharerequestid": {strconv.FormatUint(shareRequestID, 10)},
@@ -138,6 +148,7 @@ func (c *Client) CancelShareRequest(ctx context.Context, shareRequestID uint64) 
 	return c.do(ctx, "cancelsharerequest", params, &resp)
 }
 
+// ChangeShare updates the permissions on an existing share.
 func (c *Client) ChangeShare(ctx context.Context, shareID uint64, perms SharePermissions) error {
 	params := url.Values{
 		"shareid": {strconv.FormatUint(shareID, 10)},

--- a/sharing_test.go
+++ b/sharing_test.go
@@ -1,0 +1,63 @@
+package pcloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestShareFolder(t *testing.T) {
+	var gotEmail string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEmail = r.URL.Query().Get("mail")
+		json.NewEncoder(w).Encode(Share{ShareID: 9})
+	})
+
+	share, err := c.ShareFolder(context.Background(), 1, "bob@example.com", SharePermissions{CanRead: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if share.ShareID != 9 {
+		t.Fatalf("want shareid=9, got %d", share.ShareID)
+	}
+	if gotEmail != "bob@example.com" {
+		t.Fatalf("want mail=bob@example.com, got %q", gotEmail)
+	}
+}
+
+func TestShareFolderByPath(t *testing.T) {
+	var gotPath string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Query().Get("path")
+		json.NewEncoder(w).Encode(Share{ShareID: 11})
+	})
+
+	_, err := c.ShareFolderByPath(context.Background(), "/shared", "alice@example.com", SharePermissions{CanRead: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/shared" {
+		t.Fatalf("want path=/shared, got %q", gotPath)
+	}
+}
+
+func TestListShares(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(listSharesResponse{
+			Shares:   []Share{{ShareID: 1}},
+			Requests: []Share{{ShareID: 2}},
+		})
+	})
+
+	shares, requests, err := c.ListShares(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(shares) != 1 || shares[0].ShareID != 1 {
+		t.Fatalf("unexpected shares: %v", shares)
+	}
+	if len(requests) != 1 || requests[0].ShareID != 2 {
+		t.Fatalf("unexpected requests: %v", requests)
+	}
+}

--- a/stream.go
+++ b/stream.go
@@ -12,38 +12,44 @@ type FileLinkOpts struct {
 	MaxSpeed      uint64
 }
 
+func applyLinkOpts(params url.Values, opts *FileLinkOpts) {
+	if opts == nil {
+		return
+	}
+	if opts.ForceDownload {
+		params.Set("forcedownload", "1")
+	}
+	if opts.ContentType != "" {
+		params.Set("contenttype", opts.ContentType)
+	}
+	if opts.MaxSpeed > 0 {
+		params.Set("maxspeed", strconv.FormatUint(opts.MaxSpeed, 10))
+	}
+}
+
+func (c *Client) getFileLink(ctx context.Context, params url.Values, opts *FileLinkOpts) (*FileLink, error) {
+	applyLinkOpts(params, opts)
+	var resp FileLink
+	if err := c.do(ctx, "getfilelink", params, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 func (c *Client) GetFileLink(ctx context.Context, fileID uint64) (*FileLink, error) {
-	return c.GetFileLinkWithOpts(ctx, fileID, nil)
+	return c.getFileLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, nil)
 }
 
 func (c *Client) GetFileLinkByPath(ctx context.Context, path string) (*FileLink, error) {
-	return c.GetFileLinkByPathWithOpts(ctx, path, nil)
+	return c.getFileLink(ctx, url.Values{"path": {path}}, nil)
 }
 
 func (c *Client) GetFileLinkWithOpts(ctx context.Context, fileID uint64, opts *FileLinkOpts) (*FileLink, error) {
-	params := url.Values{
-		"fileid": {strconv.FormatUint(fileID, 10)},
-	}
-	applyLinkOpts(params, opts)
-
-	var resp FileLink
-	if err := c.do(ctx, "getfilelink", params, &resp); err != nil {
-		return nil, err
-	}
-	return &resp, nil
+	return c.getFileLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, opts)
 }
 
 func (c *Client) GetFileLinkByPathWithOpts(ctx context.Context, path string, opts *FileLinkOpts) (*FileLink, error) {
-	params := url.Values{
-		"path": {path},
-	}
-	applyLinkOpts(params, opts)
-
-	var resp FileLink
-	if err := c.do(ctx, "getfilelink", params, &resp); err != nil {
-		return nil, err
-	}
-	return &resp, nil
+	return c.getFileLink(ctx, url.Values{"path": {path}}, opts)
 }
 
 func (c *Client) getMediaLink(ctx context.Context, fileID uint64, endpoint string) (*FileLink, error) {
@@ -68,19 +74,4 @@ func (c *Client) GetAudioLink(ctx context.Context, fileID uint64) (*FileLink, er
 
 func (c *Client) GetHLSLink(ctx context.Context, fileID uint64) (*FileLink, error) {
 	return c.getMediaLink(ctx, fileID, "gethlslink")
-}
-
-func applyLinkOpts(params url.Values, opts *FileLinkOpts) {
-	if opts == nil {
-		return
-	}
-	if opts.ForceDownload {
-		params.Set("forcedownload", "1")
-	}
-	if opts.ContentType != "" {
-		params.Set("contenttype", opts.ContentType)
-	}
-	if opts.MaxSpeed > 0 {
-		params.Set("maxspeed", strconv.FormatUint(opts.MaxSpeed, 10))
-	}
 }

--- a/stream.go
+++ b/stream.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 )
 
+// FileLinkOpts controls optional parameters for file link requests.
 type FileLinkOpts struct {
 	ForceDownload bool
 	ContentType   string
@@ -36,18 +37,22 @@ func (c *Client) getFileLink(ctx context.Context, params url.Values, opts *FileL
 	return &resp, nil
 }
 
+// GetFileLink returns a temporary direct-download URL for a file by numeric ID.
 func (c *Client) GetFileLink(ctx context.Context, fileID uint64) (*FileLink, error) {
 	return c.getFileLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, nil)
 }
 
+// GetFileLinkByPath returns a temporary direct-download URL for a file by path.
 func (c *Client) GetFileLinkByPath(ctx context.Context, path string) (*FileLink, error) {
 	return c.getFileLink(ctx, url.Values{"path": {path}}, nil)
 }
 
+// GetFileLinkWithOpts returns a direct-download URL for a file by numeric ID with options.
 func (c *Client) GetFileLinkWithOpts(ctx context.Context, fileID uint64, opts *FileLinkOpts) (*FileLink, error) {
 	return c.getFileLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, opts)
 }
 
+// GetFileLinkByPathWithOpts returns a direct-download URL for a file by path with options.
 func (c *Client) GetFileLinkByPathWithOpts(ctx context.Context, path string, opts *FileLinkOpts) (*FileLink, error) {
 	return c.getFileLink(ctx, url.Values{"path": {path}}, opts)
 }
@@ -64,14 +69,17 @@ func (c *Client) getMediaLink(ctx context.Context, fileID uint64, endpoint strin
 	return &resp, nil
 }
 
+// GetVideoLink returns a streaming URL for a video file.
 func (c *Client) GetVideoLink(ctx context.Context, fileID uint64) (*FileLink, error) {
 	return c.getMediaLink(ctx, fileID, "getvideolink")
 }
 
+// GetAudioLink returns a streaming URL for an audio file.
 func (c *Client) GetAudioLink(ctx context.Context, fileID uint64) (*FileLink, error) {
 	return c.getMediaLink(ctx, fileID, "getaudiolink")
 }
 
+// GetHLSLink returns an HLS streaming URL for a video file.
 func (c *Client) GetHLSLink(ctx context.Context, fileID uint64) (*FileLink, error) {
 	return c.getMediaLink(ctx, fileID, "gethlslink")
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,78 @@
+package pcloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestGetFileLink(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("fileid") != "10" {
+			http.Error(w, "bad fileid", http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(FileLink{
+			Path:  "/dl/file.txt",
+			Hosts: []string{"cdn.pcloud.com"},
+		})
+	})
+
+	link, err := c.GetFileLink(context.Background(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://cdn.pcloud.com/dl/file.txt"
+	if link.URL() != want {
+		t.Fatalf("want %q, got %q", want, link.URL())
+	}
+}
+
+func TestGetFileLinkByPath(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("path") != "/docs/report.pdf" {
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(FileLink{
+			Path:  "/dl/report.pdf",
+			Hosts: []string{"cdn.pcloud.com"},
+		})
+	})
+
+	link, err := c.GetFileLinkByPath(context.Background(), "/docs/report.pdf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link.URL() == "" {
+		t.Fatal("expected non-empty URL")
+	}
+}
+
+func TestGetFileLinkWithOpts(t *testing.T) {
+	var gotForceDownload string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotForceDownload = r.URL.Query().Get("forcedownload")
+		json.NewEncoder(w).Encode(FileLink{
+			Path:  "/dl/file.txt",
+			Hosts: []string{"cdn.pcloud.com"},
+		})
+	})
+
+	c.GetFileLinkWithOpts(context.Background(), 10, &FileLinkOpts{ForceDownload: true})
+	if gotForceDownload != "1" {
+		t.Fatalf("want forcedownload=1, got %q", gotForceDownload)
+	}
+}
+
+func TestGetFileLinkAPIError(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(FileLink{Error: Error{Result: 2005, Message: "not found"}})
+	})
+
+	_, err := c.GetFileLink(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/testserver_test.go
+++ b/testserver_test.go
@@ -1,0 +1,16 @@
+package pcloud
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestServer(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := NewClient(srv.URL)
+	c.auth = "test-token"
+	return c
+}

--- a/thumb.go
+++ b/thumb.go
@@ -1,0 +1,59 @@
+package pcloud
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// ThumbOpts controls optional parameters for thumbnail requests.
+type ThumbOpts struct {
+	Crop bool
+	Type string // "png" or "jpeg"; defaults to "png" if empty
+}
+
+func applyThumbOpts(params url.Values, opts *ThumbOpts) {
+	if opts == nil {
+		return
+	}
+	if opts.Crop {
+		params.Set("crop", "1")
+	}
+	if opts.Type != "" {
+		params.Set("type", opts.Type)
+	}
+}
+
+func validateThumbSize(width, height int) error {
+	if width < 1 || width > 2048 || height < 1 || height > 2048 {
+		return fmt.Errorf("thumbnail size %dx%d is out of allowed range 1–2048", width, height)
+	}
+	return nil
+}
+
+func (c *Client) getThumbnail(ctx context.Context, params url.Values, width, height int, opts *ThumbOpts) (*FileLink, error) {
+	if err := validateThumbSize(width, height); err != nil {
+		return nil, err
+	}
+	params.Set("size", fmt.Sprintf("%dx%d", width, height))
+	applyThumbOpts(params, opts)
+
+	var resp FileLink
+	if err := c.do(ctx, "getthumb", params, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetThumbnail returns a thumbnail download link for a file by numeric ID.
+// Width and height must each be between 1 and 2048 pixels.
+func (c *Client) GetThumbnail(ctx context.Context, fileID uint64, width, height int, opts *ThumbOpts) (*FileLink, error) {
+	return c.getThumbnail(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, width, height, opts)
+}
+
+// GetThumbnailByPath returns a thumbnail download link for a file by path.
+// Width and height must each be between 1 and 2048 pixels.
+func (c *Client) GetThumbnailByPath(ctx context.Context, path string, width, height int, opts *ThumbOpts) (*FileLink, error) {
+	return c.getThumbnail(ctx, url.Values{"path": {path}}, width, height, opts)
+}

--- a/thumb_test.go
+++ b/thumb_test.go
@@ -1,0 +1,86 @@
+package pcloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestGetThumbnail(t *testing.T) {
+	var gotSize, gotFileID string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotSize = r.URL.Query().Get("size")
+		gotFileID = r.URL.Query().Get("fileid")
+		json.NewEncoder(w).Encode(FileLink{
+			Path:  "/thumb/img.jpg",
+			Hosts: []string{"cdn.pcloud.com"},
+		})
+	})
+
+	link, err := c.GetThumbnail(context.Background(), 10, 200, 150, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link.URL() == "" {
+		t.Fatal("expected non-empty URL")
+	}
+	if gotSize != "200x150" {
+		t.Fatalf("want size=200x150, got %q", gotSize)
+	}
+	if gotFileID != "10" {
+		t.Fatalf("want fileid=10, got %q", gotFileID)
+	}
+}
+
+func TestGetThumbnailByPath(t *testing.T) {
+	var gotPath string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Query().Get("path")
+		json.NewEncoder(w).Encode(FileLink{
+			Path:  "/thumb/img.jpg",
+			Hosts: []string{"cdn.pcloud.com"},
+		})
+	})
+
+	_, err := c.GetThumbnailByPath(context.Background(), "/photo.jpg", 100, 100, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/photo.jpg" {
+		t.Fatalf("want path=/photo.jpg, got %q", gotPath)
+	}
+}
+
+func TestGetThumbnailWithOpts(t *testing.T) {
+	var gotCrop, gotType string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotCrop = r.URL.Query().Get("crop")
+		gotType = r.URL.Query().Get("type")
+		json.NewEncoder(w).Encode(FileLink{
+			Path:  "/thumb/img.png",
+			Hosts: []string{"cdn.pcloud.com"},
+		})
+	})
+
+	c.GetThumbnail(context.Background(), 1, 64, 64, &ThumbOpts{Crop: true, Type: "png"})
+	if gotCrop != "1" {
+		t.Fatalf("want crop=1, got %q", gotCrop)
+	}
+	if gotType != "png" {
+		t.Fatalf("want type=png, got %q", gotType)
+	}
+}
+
+func TestGetThumbnailInvalidSize(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(FileLink{})
+	})
+
+	if _, err := c.GetThumbnail(context.Background(), 1, 0, 100, nil); err == nil {
+		t.Fatal("expected error for width=0")
+	}
+	if _, err := c.GetThumbnail(context.Background(), 1, 100, 2049, nil); err == nil {
+		t.Fatal("expected error for height=2049")
+	}
+}

--- a/trash.go
+++ b/trash.go
@@ -1,0 +1,57 @@
+package pcloud
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+)
+
+// TrashItem describes a file or folder in the pCloud trash.
+type TrashItem struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Path     string `json:"path"`
+	IsFolder bool   `json:"isfolder"`
+	FileID   uint64 `json:"fileid,omitempty"`
+	FolderID uint64 `json:"folderid,omitempty"`
+	Size     uint64 `json:"size,omitempty"`
+	Deleted  Time   `json:"deleted"`
+}
+
+type trashListResponse struct {
+	Error
+	Items []TrashItem `json:"items"`
+}
+
+// ListTrash returns all files and folders currently in the trash.
+func (c *Client) ListTrash(ctx context.Context) ([]TrashItem, error) {
+	var resp trashListResponse
+	if err := c.do(ctx, "trash_list", url.Values{}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+}
+
+func (c *Client) restoreFromTrash(ctx context.Context, params url.Values) (*Metadata, error) {
+	var resp metadataResponse
+	if err := c.do(ctx, "trash_restoretofolder", params, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Metadata, nil
+}
+
+// RestoreFromTrash restores a trashed file to its original location by file ID.
+func (c *Client) RestoreFromTrash(ctx context.Context, fileID uint64) (*Metadata, error) {
+	return c.restoreFromTrash(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+}
+
+// RestoreFromTrashByPath restores a trashed item by its path.
+func (c *Client) RestoreFromTrashByPath(ctx context.Context, path string) (*Metadata, error) {
+	return c.restoreFromTrash(ctx, url.Values{"path": {path}})
+}
+
+// EmptyTrash permanently deletes all items in the trash.
+func (c *Client) EmptyTrash(ctx context.Context) error {
+	var resp Error
+	return c.do(ctx, "trash_clear", url.Values{}, &resp)
+}

--- a/trash_test.go
+++ b/trash_test.go
@@ -1,0 +1,87 @@
+package pcloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestListTrash(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/trash_list" {
+			http.Error(w, "wrong endpoint", http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(trashListResponse{
+			Items: []TrashItem{
+				{Name: "old.txt", FileID: 1},
+				{Name: "archive", IsFolder: true, FolderID: 2},
+			},
+		})
+	})
+
+	items, err := c.ListTrash(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(items))
+	}
+	if items[0].Name != "old.txt" {
+		t.Fatalf("want old.txt, got %q", items[0].Name)
+	}
+}
+
+func TestRestoreFromTrash(t *testing.T) {
+	var gotFileID string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotFileID = r.URL.Query().Get("fileid")
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{Name: "old.txt"},
+		})
+	})
+
+	meta, err := c.RestoreFromTrash(context.Background(), 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Name != "old.txt" {
+		t.Fatalf("want old.txt, got %q", meta.Name)
+	}
+	if gotFileID != "42" {
+		t.Fatalf("want fileid=42, got %q", gotFileID)
+	}
+}
+
+func TestRestoreFromTrashByPath(t *testing.T) {
+	var gotPath string
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Query().Get("path")
+		json.NewEncoder(w).Encode(metadataResponse{
+			Metadata: Metadata{Name: "old.txt"},
+		})
+	})
+
+	_, err := c.RestoreFromTrashByPath(context.Background(), "/trash/old.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/trash/old.txt" {
+		t.Fatalf("want path=/trash/old.txt, got %q", gotPath)
+	}
+}
+
+func TestEmptyTrash(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/trash_clear" {
+			http.Error(w, "wrong endpoint", http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(Error{Result: 0})
+	})
+
+	if err := c.EmptyTrash(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -35,7 +35,7 @@ func (t Time) MarshalJSON() ([]byte, error) {
 	if t.IsZero() {
 		return []byte(`""`), nil
 	}
-	return json.Marshal(t.Time.Format(time.RFC1123Z))
+	return json.Marshal(t.Format(time.RFC1123Z))
 }
 
 // UnmarshalJSON decodes a pCloud RFC1123Z date string into Time.

--- a/types.go
+++ b/types.go
@@ -10,6 +10,11 @@ type apiError interface {
 	Err() error
 }
 
+type metadataResponse struct {
+	Error
+	Metadata Metadata `json:"metadata"`
+}
+
 type Time struct {
 	time.Time
 }

--- a/types.go
+++ b/types.go
@@ -20,6 +20,13 @@ type Time struct {
 	time.Time
 }
 
+func (t Time) MarshalJSON() ([]byte, error) {
+	if t.IsZero() {
+		return []byte(`""`), nil
+	}
+	return json.Marshal(t.Time.Format(time.RFC1123Z))
+}
+
 func (t *Time) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types.go
+++ b/types.go
@@ -7,6 +7,15 @@ import (
 	"time"
 )
 
+// Common pCloud API error codes returned in Error.Result.
+const (
+	ErrAuthRequired  = 1000
+	ErrInvalidName   = 2001
+	ErrAccessDenied  = 2003
+	ErrAlreadyExists = 2004
+	ErrNotFound      = 2005
+)
+
 type apiError interface {
 	Err() error
 }
@@ -16,10 +25,12 @@ type metadataResponse struct {
 	Metadata Metadata `json:"metadata"`
 }
 
+// Time wraps time.Time to handle pCloud's RFC1123Z date format in JSON.
 type Time struct {
 	time.Time
 }
 
+// MarshalJSON encodes Time as RFC1123Z string, or "" for zero value.
 func (t Time) MarshalJSON() ([]byte, error) {
 	if t.IsZero() {
 		return []byte(`""`), nil
@@ -27,6 +38,7 @@ func (t Time) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Time.Format(time.RFC1123Z))
 }
 
+// UnmarshalJSON decodes a pCloud RFC1123Z date string into Time.
 func (t *Time) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
@@ -43,8 +55,10 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Hash is a file content hash. pCloud may return it as a string or number.
 type Hash string
 
+// UnmarshalJSON decodes a pCloud hash value, which may be a JSON string or number.
 func (h *Hash) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
@@ -59,11 +73,14 @@ func (h *Hash) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("hash: cannot unmarshal %s", string(data))
 }
 
+// Error represents a pCloud API error response.
+// Result holds the numeric code; zero means success.
 type Error struct {
 	Result  int    `json:"result"`
 	Message string `json:"error"`
 }
 
+// Err returns nil when Result is 0, otherwise returns the Error itself.
 func (e *Error) Err() error {
 	if e.Result == 0 {
 		return nil
@@ -71,6 +88,7 @@ func (e *Error) Err() error {
 	return e
 }
 
+// Error implements the error interface.
 func (e *Error) Error() string {
 	if e.Message == "" {
 		return fmt.Sprintf("pcloud error %d", e.Result)
@@ -78,6 +96,7 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("pcloud error %d: %s", e.Result, e.Message)
 }
 
+// Metadata describes a pCloud file or folder.
 type Metadata struct {
 	ID          string     `json:"id"`
 	Name        string     `json:"name"`
@@ -99,6 +118,7 @@ type Metadata struct {
 	Contents    []Metadata `json:"contents,omitempty"`
 }
 
+// Revision describes a historical version of a pCloud file.
 type Revision struct {
 	RevisionID uint64 `json:"revisionid"`
 	Size       uint64 `json:"size"`
@@ -106,6 +126,7 @@ type Revision struct {
 	Created    Time   `json:"created"`
 }
 
+// UserInfo holds account details returned by the userinfo endpoint.
 type UserInfo struct {
 	Error
 	UserID         uint64 `json:"userid"`
@@ -119,6 +140,7 @@ type UserInfo struct {
 	UsedQuota      uint64 `json:"usedquota"`
 }
 
+// FileLink holds a temporary direct-download URL returned by streaming endpoints.
 type FileLink struct {
 	Error
 	Path    string   `json:"path"`
@@ -126,6 +148,7 @@ type FileLink struct {
 	Hosts   []string `json:"hosts"`
 }
 
+// URL returns the first available download URL for this FileLink.
 func (f *FileLink) URL() string {
 	if len(f.Hosts) == 0 {
 		return ""

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package pcloud
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -45,7 +46,7 @@ func (h *Hash) UnmarshalJSON(data []byte) error {
 	}
 	var n uint64
 	if err := json.Unmarshal(data, &n); err == nil {
-		*h = ""
+		*h = Hash(strconv.FormatUint(n, 10))
 		return nil
 	}
 	return fmt.Errorf("hash: cannot unmarshal %s", string(data))

--- a/types.go
+++ b/types.go
@@ -59,7 +59,10 @@ func (e *Error) Err() error {
 }
 
 func (e *Error) Error() string {
-	return e.Message
+	if e.Message == "" {
+		return fmt.Sprintf("pcloud error %d", e.Result)
+	}
+	return fmt.Sprintf("pcloud error %d: %s", e.Result, e.Message)
 }
 
 type Metadata struct {

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,90 @@
+package pcloud
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestHashUnmarshalString(t *testing.T) {
+	var h Hash
+	if err := json.Unmarshal([]byte(`"abc123"`), &h); err != nil {
+		t.Fatal(err)
+	}
+	if h != "abc123" {
+		t.Fatalf("want abc123, got %q", h)
+	}
+}
+
+func TestHashUnmarshalNumber(t *testing.T) {
+	var h Hash
+	if err := json.Unmarshal([]byte(`12345678`), &h); err != nil {
+		t.Fatal(err)
+	}
+	if h != "12345678" {
+		t.Fatalf("want 12345678, got %q", h)
+	}
+}
+
+func TestHashUnmarshalInvalid(t *testing.T) {
+	var h Hash
+	if err := json.Unmarshal([]byte(`true`), &h); err == nil {
+		t.Fatal("expected error for boolean hash")
+	}
+}
+
+func TestTimeUnmarshalValid(t *testing.T) {
+	var ts Time
+	if err := json.Unmarshal([]byte(`"Mon, 02 Jan 2006 15:04:05 -0700"`), &ts); err != nil {
+		t.Fatal(err)
+	}
+	if ts.IsZero() {
+		t.Fatal("expected non-zero time")
+	}
+}
+
+func TestTimeUnmarshalEmpty(t *testing.T) {
+	var ts Time
+	if err := json.Unmarshal([]byte(`""`), &ts); err != nil {
+		t.Fatal(err)
+	}
+	if !ts.IsZero() {
+		t.Fatal("expected zero time for empty string")
+	}
+}
+
+func TestErrorErr(t *testing.T) {
+	e := &Error{Result: 0}
+	if e.Err() != nil {
+		t.Fatal("result=0 should return nil error")
+	}
+
+	e = &Error{Result: 2005, Message: "not found"}
+	if e.Err() == nil {
+		t.Fatal("result!=0 should return error")
+	}
+	if e.Error() != "pcloud error 2005: not found" {
+		t.Fatalf("unexpected error string: %s", e.Error())
+	}
+}
+
+func TestErrorErrNoMessage(t *testing.T) {
+	e := &Error{Result: 1000}
+	if e.Error() != "pcloud error 1000" {
+		t.Fatalf("unexpected error string: %s", e.Error())
+	}
+}
+
+func TestFileLinkURL(t *testing.T) {
+	f := &FileLink{Path: "/dl/file.txt", Hosts: []string{"cdn1.pcloud.com"}}
+	want := "https://cdn1.pcloud.com/dl/file.txt"
+	if f.URL() != want {
+		t.Fatalf("want %q, got %q", want, f.URL())
+	}
+}
+
+func TestFileLinkURLNoHosts(t *testing.T) {
+	f := &FileLink{Path: "/dl/file.txt"}
+	if f.URL() != "" {
+		t.Fatalf("expected empty URL, got %q", f.URL())
+	}
+}


### PR DESCRIPTION
## Why

The client library needed modernization (Go 1.25+, better error handling, reduced duplication) and was missing unit tests and several commonly-used pCloud API endpoints.

## Changes

- **Refactor**: extract shared request logic, deduplicate ID/path method pairs via private helpers, add HTTP timeout, simplify error handling
- **Fix**: correct `Hash` numeric unmarshaling, unify `metadataResponse`
- **Tests**: add httptest-based unit tests for all endpoints (client, files, folders, streams, publinks, revisions, sharing, types)
- **Features**: add trash (list/restore/empty), search, thumbnails, favorites endpoints
- **Docs**: add godoc comments to all exported symbols, add runnable examples

## Reviewers: focus on

- The `do`/`doPost` refactor in `client.go` — shared request path changed
- New endpoint API surface (trash, search, thumb, favorites) for consistency with existing patterns
- Test coverage adequacy via the mock server approach

## Testing

- All new endpoints have unit tests using `httptest` mock server
- Existing integration tests unchanged (run with `PCLOUD_USERNAME`/`PCLOUD_PASSWORD`)