### PR TITLE
refactor: use modern Go idioms across codebase

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package pcloud
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -39,11 +40,8 @@ type Client struct {
 // NewClient creates a new Client for the given base URL.
 // Pass BaseURLUS or BaseURLEU; an empty string defaults to BaseURLUS.
 func NewClient(baseURL string) *Client {
-	if baseURL == "" {
-		baseURL = BaseURLUS
-	}
 	return &Client{
-		baseURL:    baseURL,
+		baseURL:    cmp.Or(baseURL, BaseURLUS),
 		httpClient: &http.Client{Timeout: DefaultTimeout},
 		logger:     newNoopLogger(),
 		limiter:    rate.NewLimiter(rate.Limit(MinRPM/60.0), 10),

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,6 @@
 package pcloud
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -37,7 +36,7 @@ func TestRequestAuthInjected(t *testing.T) {
 	})
 
 	var resp Error
-	if err := c.do(context.Background(), "ping", url.Values{}, &resp); err != nil {
+	if err := c.do(t.Context(), "ping", url.Values{}, &resp); err != nil {
 		t.Fatal(err)
 	}
 	if gotAuth != "test-token" {
@@ -51,7 +50,7 @@ func TestRequestAPIError(t *testing.T) {
 	})
 
 	var resp Error
-	err := c.do(context.Background(), "stat", url.Values{}, &resp)
+	err := c.do(t.Context(), "stat", url.Values{}, &resp)
 	if err == nil {
 		t.Fatal("expected error from API result=2005")
 	}

--- a/favorites_test.go
+++ b/favorites_test.go
@@ -1,7 +1,6 @@
 package pcloud
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -21,7 +20,7 @@ func TestListFavorites(t *testing.T) {
 		})
 	})
 
-	items, err := c.ListFavorites(context.Background())
+	items, err := c.ListFavorites(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +36,7 @@ func TestAddFavorite(t *testing.T) {
 		json.NewEncoder(w).Encode(Error{Result: 0})
 	})
 
-	if err := c.AddFavorite(context.Background(), 55); err != nil {
+	if err := c.AddFavorite(t.Context(), 55); err != nil {
 		t.Fatal(err)
 	}
 	if gotFileID != "55" {
@@ -52,7 +51,7 @@ func TestAddFavoriteByPath(t *testing.T) {
 		json.NewEncoder(w).Encode(Error{Result: 0})
 	})
 
-	if err := c.AddFavoriteByPath(context.Background(), "/docs/fav.pdf"); err != nil {
+	if err := c.AddFavoriteByPath(t.Context(), "/docs/fav.pdf"); err != nil {
 		t.Fatal(err)
 	}
 	if gotPath != "/docs/fav.pdf" {
@@ -67,7 +66,7 @@ func TestRemoveFavorite(t *testing.T) {
 		json.NewEncoder(w).Encode(Error{Result: 0})
 	})
 
-	if err := c.RemoveFavorite(context.Background(), 77); err != nil {
+	if err := c.RemoveFavorite(t.Context(), 77); err != nil {
 		t.Fatal(err)
 	}
 	if gotFileID != "77" {
@@ -82,7 +81,7 @@ func TestRemoveFavoriteByPath(t *testing.T) {
 		json.NewEncoder(w).Encode(Error{Result: 0})
 	})
 
-	if err := c.RemoveFavoriteByPath(context.Background(), "/docs/unfav.pdf"); err != nil {
+	if err := c.RemoveFavoriteByPath(t.Context(), "/docs/unfav.pdf"); err != nil {
 		t.Fatal(err)
 	}
 	if gotPath != "/docs/unfav.pdf" {

--- a/file_test.go
+++ b/file_test.go
@@ -2,7 +2,6 @@ package pcloud
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -22,7 +21,7 @@ func TestStat(t *testing.T) {
 		})
 	})
 
-	meta, err := c.Stat(context.Background(), 123)
+	meta, err := c.Stat(t.Context(), 123)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +41,7 @@ func TestStatByPath(t *testing.T) {
 		})
 	})
 
-	meta, err := c.StatByPath(context.Background(), "/photo.jpg")
+	meta, err := c.StatByPath(t.Context(), "/photo.jpg")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +57,7 @@ func TestDeleteFile(t *testing.T) {
 		json.NewEncoder(w).Encode(Error{Result: 0})
 	})
 
-	if err := c.DeleteFile(context.Background(), 55); err != nil {
+	if err := c.DeleteFile(t.Context(), 55); err != nil {
 		t.Fatal(err)
 	}
 	if gotFileID != "55" {
@@ -73,7 +72,7 @@ func TestDeleteFileByPath(t *testing.T) {
 		json.NewEncoder(w).Encode(Error{Result: 0})
 	})
 
-	if err := c.DeleteFileByPath(context.Background(), "/old.txt"); err != nil {
+	if err := c.DeleteFileByPath(t.Context(), "/old.txt"); err != nil {
 		t.Fatal(err)
 	}
 	if gotPath != "/old.txt" {
@@ -89,7 +88,7 @@ func TestUpload(t *testing.T) {
 	})
 
 	content := bytes.NewReader([]byte("hello"))
-	meta, err := c.Upload(context.Background(), 0, "hello.txt", content, nil)
+	meta, err := c.Upload(t.Context(), 0, "hello.txt", content, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/folder_test.go
+++ b/folder_test.go
@@ -1,7 +1,6 @@
 package pcloud
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -18,7 +17,7 @@ func TestListFolder(t *testing.T) {
 		})
 	})
 
-	meta, err := c.ListFolder(context.Background(), 0, nil)
+	meta, err := c.ListFolder(t.Context(), 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +37,7 @@ func TestListFolderByPath(t *testing.T) {
 		})
 	})
 
-	meta, err := c.ListFolderByPath(context.Background(), "/myfolder", nil)
+	meta, err := c.ListFolderByPath(t.Context(), "/myfolder", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +51,7 @@ func TestListFolderAPIError(t *testing.T) {
 		json.NewEncoder(w).Encode(metadataResponse{Error: Error{Result: 2005, Message: "not found"}})
 	})
 
-	_, err := c.ListFolder(context.Background(), 999, nil)
+	_, err := c.ListFolder(t.Context(), 999, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -65,7 +64,7 @@ func TestListFolderOpts(t *testing.T) {
 		json.NewEncoder(w).Encode(metadataResponse{})
 	})
 
-	c.ListFolder(context.Background(), 0, &ListFolderOpts{Recursive: true})
+	c.ListFolder(t.Context(), 0, &ListFolderOpts{Recursive: true})
 	if gotRecursive != "1" {
 		t.Fatalf("want recursive=1, got %q", gotRecursive)
 	}
@@ -78,7 +77,7 @@ func TestStatFolder(t *testing.T) {
 		})
 	})
 
-	meta, err := c.StatFolder(context.Background(), 42)
+	meta, err := c.StatFolder(t.Context(), 42)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +97,7 @@ func TestStatFolderByPath(t *testing.T) {
 		})
 	})
 
-	meta, err := c.StatFolderByPath(context.Background(), "/docs")
+	meta, err := c.StatFolderByPath(t.Context(), "/docs")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +113,7 @@ func TestCreateFolder(t *testing.T) {
 		})
 	})
 
-	meta, err := c.CreateFolder(context.Background(), 0, "new-dir")
+	meta, err := c.CreateFolder(t.Context(), 0, "new-dir")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +138,7 @@ func TestWalkYieldsContents(t *testing.T) {
 	})
 
 	var names []string
-	for item, err := range c.Walk(context.Background(), 0) {
+	for item, err := range c.Walk(t.Context(), 0) {
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -166,7 +165,7 @@ func TestWalkEarlyBreak(t *testing.T) {
 	})
 
 	var count int
-	for _, err := range c.Walk(context.Background(), 0) {
+	for _, err := range c.Walk(t.Context(), 0) {
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/publink_test.go
+++ b/publink_test.go
@@ -1,7 +1,6 @@
 package pcloud
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -14,7 +13,7 @@ func TestCreateFilePublicLink(t *testing.T) {
 		json.NewEncoder(w).Encode(PublicLink{LinkID: 7, Code: "abc"})
 	})
 
-	link, err := c.CreateFilePublicLink(context.Background(), 42, nil)
+	link, err := c.CreateFilePublicLink(t.Context(), 42, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +32,7 @@ func TestCreateFilePublicLinkByPath(t *testing.T) {
 		json.NewEncoder(w).Encode(PublicLink{LinkID: 8})
 	})
 
-	_, err := c.CreateFilePublicLinkByPath(context.Background(), "/report.pdf", nil)
+	_, err := c.CreateFilePublicLinkByPath(t.Context(), "/report.pdf", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +49,7 @@ func TestCreateFilePublicLinkOpts(t *testing.T) {
 		json.NewEncoder(w).Encode(PublicLink{})
 	})
 
-	c.CreateFilePublicLink(context.Background(), 1, &PublicLinkOpts{
+	c.CreateFilePublicLink(t.Context(), 1, &PublicLinkOpts{
 		ExpireAt:     1700000000,
 		MaxDownloads: 5,
 	})
@@ -69,7 +68,7 @@ func TestListPublicLinks(t *testing.T) {
 		})
 	})
 
-	links, err := c.ListPublicLinks(context.Background())
+	links, err := c.ListPublicLinks(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +84,7 @@ func TestDeletePublicLink(t *testing.T) {
 		json.NewEncoder(w).Encode(Error{Result: 0})
 	})
 
-	if err := c.DeletePublicLink(context.Background(), 15); err != nil {
+	if err := c.DeletePublicLink(t.Context(), 15); err != nil {
 		t.Fatal(err)
 	}
 	if gotLinkID != "15" {

--- a/revision_test.go
+++ b/revision_test.go
@@ -1,7 +1,6 @@
 package pcloud
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -21,7 +20,7 @@ func TestListRevisions(t *testing.T) {
 		})
 	})
 
-	revs, err := c.ListRevisions(context.Background(), 20)
+	revs, err := c.ListRevisions(t.Context(), 20)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +40,7 @@ func TestListRevisionsByPath(t *testing.T) {
 		})
 	})
 
-	revs, err := c.ListRevisionsByPath(context.Background(), "/file.txt")
+	revs, err := c.ListRevisionsByPath(t.Context(), "/file.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +58,7 @@ func TestRevertRevision(t *testing.T) {
 		})
 	})
 
-	meta, err := c.RevertRevision(context.Background(), 20, 3)
+	meta, err := c.RevertRevision(t.Context(), 20, 3)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/search_test.go
+++ b/search_test.go
@@ -1,7 +1,6 @@
 package pcloud
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -19,7 +18,7 @@ func TestSearch(t *testing.T) {
 		})
 	})
 
-	items, err := c.Search(context.Background(), "report", nil)
+	items, err := c.Search(t.Context(), "report", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +38,7 @@ func TestSearchWithOpts(t *testing.T) {
 		json.NewEncoder(w).Encode(searchResponse{})
 	})
 
-	c.Search(context.Background(), "img", &SearchOpts{FolderID: 10, Recursive: true})
+	c.Search(t.Context(), "img", &SearchOpts{FolderID: 10, Recursive: true})
 	if gotFolderID != "10" {
 		t.Fatalf("want folderid=10, got %q", gotFolderID)
 	}
@@ -53,7 +52,7 @@ func TestSearchAPIError(t *testing.T) {
 		json.NewEncoder(w).Encode(searchResponse{Error: Error{Result: 2003, Message: "access denied"}})
 	})
 
-	_, err := c.Search(context.Background(), "secret", nil)
+	_, err := c.Search(t.Context(), "secret", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/sharing_test.go
+++ b/sharing_test.go
@@ -1,7 +1,6 @@
 package pcloud
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -14,7 +13,7 @@ func TestShareFolder(t *testing.T) {
 		json.NewEncoder(w).Encode(Share{ShareID: 9})
 	})
 
-	share, err := c.ShareFolder(context.Background(), 1, "bob@example.com", SharePermissions{CanRead: true}, nil)
+	share, err := c.ShareFolder(t.Context(), 1, "bob@example.com", SharePermissions{CanRead: true}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +32,7 @@ func TestShareFolderByPath(t *testing.T) {
 		json.NewEncoder(w).Encode(Share{ShareID: 11})
 	})
 
-	_, err := c.ShareFolderByPath(context.Background(), "/shared", "alice@example.com", SharePermissions{CanRead: true}, nil)
+	_, err := c.ShareFolderByPath(t.Context(), "/shared", "alice@example.com", SharePermissions{CanRead: true}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +49,7 @@ func TestListShares(t *testing.T) {
 		})
 	})
 
-	shares, requests, err := c.ListShares(context.Background())
+	shares, requests, err := c.ListShares(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,7 +1,6 @@
 package pcloud
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -19,7 +18,7 @@ func TestGetFileLink(t *testing.T) {
 		})
 	})
 
-	link, err := c.GetFileLink(context.Background(), 10)
+	link, err := c.GetFileLink(t.Context(), 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +40,7 @@ func TestGetFileLinkByPath(t *testing.T) {
 		})
 	})
 
-	link, err := c.GetFileLinkByPath(context.Background(), "/docs/report.pdf")
+	link, err := c.GetFileLinkByPath(t.Context(), "/docs/report.pdf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +59,7 @@ func TestGetFileLinkWithOpts(t *testing.T) {
 		})
 	})
 
-	c.GetFileLinkWithOpts(context.Background(), 10, &FileLinkOpts{ForceDownload: true})
+	c.GetFileLinkWithOpts(t.Context(), 10, &FileLinkOpts{ForceDownload: true})
 	if gotForceDownload != "1" {
 		t.Fatalf("want forcedownload=1, got %q", gotForceDownload)
 	}
@@ -71,7 +70,7 @@ func TestGetFileLinkAPIError(t *testing.T) {
 		json.NewEncoder(w).Encode(FileLink{Error: Error{Result: 2005, Message: "not found"}})
 	})
 
-	_, err := c.GetFileLink(context.Background(), 999)
+	_, err := c.GetFileLink(t.Context(), 999)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -22,7 +22,7 @@ func getClient(t *testing.T) (*pcloud.Client, context.Context) {
 
 	baseURL := os.Getenv("PCLOUD_BASE_URL")
 	c := pcloud.NewClient(baseURL)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	if err := c.Login(ctx, username, password); err != nil {
 		t.Fatalf("login failed: %v", err)
@@ -40,7 +40,7 @@ func TestAuth(t *testing.T) {
 
 	baseURL := os.Getenv("PCLOUD_BASE_URL")
 	c := pcloud.NewClient(baseURL)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("Login", func(t *testing.T) {
 		if err := c.Login(ctx, username, password); err != nil {

--- a/thumb_test.go
+++ b/thumb_test.go
@@ -1,7 +1,6 @@
 package pcloud
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -18,7 +17,7 @@ func TestGetThumbnail(t *testing.T) {
 		})
 	})
 
-	link, err := c.GetThumbnail(context.Background(), 10, 200, 150, nil)
+	link, err := c.GetThumbnail(t.Context(), 10, 200, 150, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +42,7 @@ func TestGetThumbnailByPath(t *testing.T) {
 		})
 	})
 
-	_, err := c.GetThumbnailByPath(context.Background(), "/photo.jpg", 100, 100, nil)
+	_, err := c.GetThumbnailByPath(t.Context(), "/photo.jpg", 100, 100, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +62,7 @@ func TestGetThumbnailWithOpts(t *testing.T) {
 		})
 	})
 
-	c.GetThumbnail(context.Background(), 1, 64, 64, &ThumbOpts{Crop: true, Type: "png"})
+	c.GetThumbnail(t.Context(), 1, 64, 64, &ThumbOpts{Crop: true, Type: "png"})
 	if gotCrop != "1" {
 		t.Fatalf("want crop=1, got %q", gotCrop)
 	}
@@ -77,10 +76,10 @@ func TestGetThumbnailInvalidSize(t *testing.T) {
 		json.NewEncoder(w).Encode(FileLink{})
 	})
 
-	if _, err := c.GetThumbnail(context.Background(), 1, 0, 100, nil); err == nil {
+	if _, err := c.GetThumbnail(t.Context(), 1, 0, 100, nil); err == nil {
 		t.Fatal("expected error for width=0")
 	}
-	if _, err := c.GetThumbnail(context.Background(), 1, 100, 2049, nil); err == nil {
+	if _, err := c.GetThumbnail(t.Context(), 1, 100, 2049, nil); err == nil {
 		t.Fatal("expected error for height=2049")
 	}
 }

--- a/trash_test.go
+++ b/trash_test.go
@@ -1,7 +1,6 @@
 package pcloud
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -21,7 +20,7 @@ func TestListTrash(t *testing.T) {
 		})
 	})
 
-	items, err := c.ListTrash(context.Background())
+	items, err := c.ListTrash(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +41,7 @@ func TestRestoreFromTrash(t *testing.T) {
 		})
 	})
 
-	meta, err := c.RestoreFromTrash(context.Background(), 42)
+	meta, err := c.RestoreFromTrash(t.Context(), 42)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +62,7 @@ func TestRestoreFromTrashByPath(t *testing.T) {
 		})
 	})
 
-	_, err := c.RestoreFromTrashByPath(context.Background(), "/trash/old.txt")
+	_, err := c.RestoreFromTrashByPath(t.Context(), "/trash/old.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +80,7 @@ func TestEmptyTrash(t *testing.T) {
 		json.NewEncoder(w).Encode(Error{Result: 0})
 	})
 
-	if err := c.EmptyTrash(context.Background()); err != nil {
+	if err := c.EmptyTrash(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -112,10 +112,10 @@ type Metadata struct {
 	ParentID    uint64     `json:"parentfolderid,omitempty"`
 	Size        uint64     `json:"size,omitempty"`
 	ContentType string     `json:"contenttype,omitempty"`
-	Hash        Hash       `json:"hash,omitempty"`
+	Hash        Hash       `json:"hash,omitzero"`
 	Category    int        `json:"category,omitempty"`
 	Thumb       bool       `json:"thumb,omitempty"`
-	Contents    []Metadata `json:"contents,omitempty"`
+	Contents    []Metadata `json:"contents,omitzero"`
 }
 
 // Revision describes a historical version of a pCloud file.
@@ -135,7 +135,7 @@ type UserInfo struct {
 	Registered     Time   `json:"registered"`
 	Language       string `json:"language"`
 	Premium        bool   `json:"premium"`
-	PremiumExpires Time   `json:"premiumexpires,omitempty"`
+	PremiumExpires Time   `json:"premiumexpires,omitzero"`
 	Quota          uint64 `json:"quota"`
 	UsedQuota      uint64 `json:"usedquota"`
 }


### PR DESCRIPTION
## Changes
- Use `cmp.Or` for default value assignment in `NewClient` instead of if/else
- Use `omitzero` struct tags for non-scalar types (`Hash`, `[]Metadata`, `Time`) where `omitempty` doesn't behave correctly
- Replace `context.Background()` with `t.Context()` in all tests

## Testing
- All changes are mechanical substitutions of equivalent modern Go stdlib APIs
- Existing test suite covers all affected code paths