### PR TITLE
refactor: thread safety, typed errors, and API cleanup

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,6 +135,7 @@ linters:
           - errcheck
           - gocyclo
           - gocritic
+          - gosec
       - path: example_test\.go
         linters:
           - errcheck

--- a/auth.go
+++ b/auth.go
@@ -23,7 +23,9 @@ func (c *Client) Login(ctx context.Context, username, password string) error {
 		return err
 	}
 
+	c.mu.Lock()
 	c.auth = resp.Auth
+	c.mu.Unlock()
 	return nil
 }
 
@@ -34,7 +36,9 @@ func (c *Client) Logout(ctx context.Context) error {
 		return err
 	}
 
+	c.mu.Lock()
 	c.auth = ""
+	c.mu.Unlock()
 	return nil
 }
 

--- a/auth.go
+++ b/auth.go
@@ -2,6 +2,7 @@ package pcloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 )
 
@@ -20,7 +21,7 @@ func (c *Client) Login(ctx context.Context, username, password string) error {
 
 	var resp loginResponse
 	if err := c.do(ctx, "userinfo", params, &resp); err != nil {
-		return err
+		return fmt.Errorf("login: %w", err)
 	}
 
 	c.mu.Lock()
@@ -33,7 +34,7 @@ func (c *Client) Login(ctx context.Context, username, password string) error {
 func (c *Client) Logout(ctx context.Context) error {
 	var resp Error
 	if err := c.do(ctx, "logout", url.Values{}, &resp); err != nil {
-		return err
+		return fmt.Errorf("logout: %w", err)
 	}
 
 	c.mu.Lock()
@@ -46,7 +47,7 @@ func (c *Client) Logout(ctx context.Context) error {
 func (c *Client) UserInfo(ctx context.Context) (*UserInfo, error) {
 	var resp UserInfo
 	if err := c.do(ctx, "userinfo", url.Values{}, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("userinfo: %w", err)
 	}
 	return &resp, nil
 }

--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
-	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/time/rate"
@@ -23,8 +22,6 @@ const (
 	BaseURLEU = "https://eapi.pcloud.com"
 	// MinRPM is the minimum allowed rate limit in requests per minute.
 	MinRPM = 100.0
-	// DefaultTimeout is the default HTTP client timeout.
-	DefaultTimeout = 30 * time.Second
 )
 
 // Client is a pCloud API client. Use NewClient to create one.
@@ -44,7 +41,7 @@ type Client struct {
 func NewClient(baseURL string) *Client {
 	return &Client{
 		baseURL:    cmp.Or(baseURL, BaseURLUS),
-		httpClient: &http.Client{Timeout: DefaultTimeout},
+		httpClient: &http.Client{},
 		logger:     newNoopLogger(),
 		limiter:    rate.NewLimiter(rate.Limit(MinRPM/60.0), 10),
 	}

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -29,6 +30,7 @@ const (
 // Client is a pCloud API client. Use NewClient to create one.
 // All methods are safe for concurrent use.
 type Client struct {
+	mu          sync.RWMutex
 	baseURL     string
 	httpClient  *http.Client
 	auth        string
@@ -50,11 +52,15 @@ func NewClient(baseURL string) *Client {
 
 // SetHTTPClient replaces the default HTTP client.
 func (c *Client) SetHTTPClient(client *http.Client) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.httpClient = client
 }
 
 // SetLogger attaches a structured logger for request diagnostics.
 func (c *Client) SetLogger(logger *slog.Logger) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.logger = logger
 }
 
@@ -64,6 +70,8 @@ func (c *Client) SetRateLimit(rpm float64) error {
 	if rpm < MinRPM {
 		return fmt.Errorf("rate limit %.1f RPM is below minimum %.1f RPM", rpm, MinRPM)
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.limiter = rate.NewLimiter(rate.Limit(rpm/60.0), 10)
 	return nil
 }
@@ -71,6 +79,8 @@ func (c *Client) SetRateLimit(rpm float64) error {
 // SetTokenSource configures OAuth2 token-based authentication.
 // This takes precedence over username/password auth set via Login.
 func (c *Client) SetTokenSource(ts oauth2.TokenSource) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.tokenSource = ts
 }
 
@@ -79,12 +89,19 @@ func (c *Client) request(ctx context.Context, httpMethod, apiMethod string, para
 		return err
 	}
 
-	c.logger.Debug("request", "method", apiMethod)
-	if err := c.limiter.Wait(ctx); err != nil {
+	c.mu.RLock()
+	httpCl := c.httpClient
+	logger := c.logger
+	limiter := c.limiter
+	baseURL := c.baseURL
+	c.mu.RUnlock()
+
+	logger.Debug("request", "method", apiMethod)
+	if err := limiter.Wait(ctx); err != nil {
 		return err
 	}
 
-	reqURL := fmt.Sprintf("%s/%s?%s", c.baseURL, apiMethod, params.Encode())
+	reqURL := fmt.Sprintf("%s/%s?%s", baseURL, apiMethod, params.Encode())
 	req, err := http.NewRequestWithContext(ctx, httpMethod, reqURL, body)
 	if err != nil {
 		return err
@@ -93,15 +110,20 @@ func (c *Client) request(ctx context.Context, httpMethod, apiMethod string, para
 		req.Header.Set("Content-Type", contentType)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := httpCl.Do(req)
 	if err != nil {
-		c.logger.Error("request failed", "method", apiMethod, "error", err)
+		logger.Error("request failed", "method", apiMethod, "error", err)
 		return err
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("pcloud: %s %s: %s", httpMethod, apiMethod, resp.Status)
+	}
+
 	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
-		c.logger.Error("decode failed", "method", apiMethod, "error", err)
+		logger.Error("decode failed", "method", apiMethod, "error", err)
 		return err
 	}
 	return result.Err()
@@ -116,16 +138,21 @@ func (c *Client) doPost(ctx context.Context, method string, params url.Values, b
 }
 
 func (c *Client) setAuth(params url.Values) error {
-	if c.tokenSource != nil {
-		token, err := c.tokenSource.Token()
+	c.mu.RLock()
+	ts := c.tokenSource
+	auth := c.auth
+	c.mu.RUnlock()
+
+	if ts != nil {
+		token, err := ts.Token()
 		if err != nil {
 			return err
 		}
 		params.Set("auth", token.AccessToken)
 		return nil
 	}
-	if c.auth != "" {
-		params.Set("auth", c.auth)
+	if auth != "" {
+		params.Set("auth", auth)
 	}
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -56,5 +58,53 @@ func TestRequestAPIError(t *testing.T) {
 	}
 	if err.Error() != "pcloud error 2005: not found" {
 		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestConcurrentLoginAndRequest(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(loginResponse{Auth: "tok"})
+	})
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			c.Login(t.Context(), "u", "p")
+		}()
+		go func() {
+			defer wg.Done()
+			var resp Error
+			c.do(t.Context(), "ping", url.Values{}, &resp)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestRequestHTTP500(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("<html>Internal Server Error</html>"))
+	})
+
+	var resp Error
+	err := c.do(t.Context(), "test", url.Values{}, &resp)
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error should mention status code: %s", err)
+	}
+}
+
+func TestRequestHTTP200Valid(t *testing.T) {
+	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(Error{Result: 0})
+	})
+
+	var resp Error
+	if err := c.do(t.Context(), "test", url.Values{}, &resp); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -2,14 +2,18 @@ package pcloud
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
 	"testing"
+
+	"golang.org/x/oauth2"
 )
 
 func TestNewClientDefaultURL(t *testing.T) {
+	t.Parallel()
 	c := NewClient("")
 	if c.baseURL != BaseURLUS {
 		t.Fatalf("want %q, got %q", BaseURLUS, c.baseURL)
@@ -17,6 +21,7 @@ func TestNewClientDefaultURL(t *testing.T) {
 }
 
 func TestSetRateLimitBelowMin(t *testing.T) {
+	t.Parallel()
 	c := NewClient("")
 	if err := c.SetRateLimit(MinRPM - 1); err == nil {
 		t.Fatal("expected error for rate below MinRPM")
@@ -24,6 +29,7 @@ func TestSetRateLimitBelowMin(t *testing.T) {
 }
 
 func TestSetRateLimitValid(t *testing.T) {
+	t.Parallel()
 	c := NewClient("")
 	if err := c.SetRateLimit(MinRPM); err != nil {
 		t.Fatal(err)
@@ -31,6 +37,7 @@ func TestSetRateLimitValid(t *testing.T) {
 }
 
 func TestRequestAuthInjected(t *testing.T) {
+	t.Parallel()
 	var gotAuth string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.URL.Query().Get("auth")
@@ -47,6 +54,7 @@ func TestRequestAuthInjected(t *testing.T) {
 }
 
 func TestRequestAPIError(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(Error{Result: 2005, Message: "not found"})
 	})
@@ -62,6 +70,7 @@ func TestRequestAPIError(t *testing.T) {
 }
 
 func TestConcurrentLoginAndRequest(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(loginResponse{Auth: "tok"})
 	})
@@ -83,6 +92,7 @@ func TestConcurrentLoginAndRequest(t *testing.T) {
 }
 
 func TestRequestHTTP500(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("<html>Internal Server Error</html>"))
@@ -99,6 +109,7 @@ func TestRequestHTTP500(t *testing.T) {
 }
 
 func TestRequestHTTP200Valid(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(Error{Result: 0})
 	})
@@ -106,5 +117,51 @@ func TestRequestHTTP200Valid(t *testing.T) {
 	var resp Error
 	if err := c.do(t.Context(), "test", url.Values{}, &resp); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+type failingTokenSource struct{}
+
+func (failingTokenSource) Token() (*oauth2.Token, error) {
+	return nil, errors.New("token error")
+}
+
+func TestSetAuthWithTokenSource(t *testing.T) {
+	t.Parallel()
+	c := NewClient("")
+	c.SetTokenSource(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "oauth-token"}))
+
+	params := url.Values{}
+	if err := c.setAuth(params); err != nil {
+		t.Fatal(err)
+	}
+	if params.Get("auth") != "oauth-token" {
+		t.Fatalf("want auth=oauth-token, got %q", params.Get("auth"))
+	}
+}
+
+func TestSetAuthWithFailingTokenSource(t *testing.T) {
+	t.Parallel()
+	c := NewClient("")
+	c.SetTokenSource(failingTokenSource{})
+
+	params := url.Values{}
+	if err := c.setAuth(params); err == nil {
+		t.Fatal("expected error from failing token source")
+	}
+}
+
+func TestSetAuthTokenSourcePrecedence(t *testing.T) {
+	t.Parallel()
+	c := NewClient("")
+	c.auth = "password-auth"
+	c.SetTokenSource(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "oauth-token"}))
+
+	params := url.Values{}
+	if err := c.setAuth(params); err != nil {
+		t.Fatal(err)
+	}
+	if params.Get("auth") != "oauth-token" {
+		t.Fatalf("want oauth-token (precedence), got %q", params.Get("auth"))
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,51 @@
+package pcloud
+
+import (
+	"errors"
+	"fmt"
+)
+
+type ErrorCode int
+
+const (
+	ErrAuthRequired  ErrorCode = 1000
+	ErrInvalidName   ErrorCode = 2001
+	ErrAccessDenied  ErrorCode = 2003
+	ErrAlreadyExists ErrorCode = 2004
+	ErrNotFound      ErrorCode = 2005
+)
+
+type apiError interface {
+	Err() error
+}
+
+// Error represents a pCloud API error response.
+// Result holds the numeric code; zero means success.
+type Error struct {
+	Result  ErrorCode `json:"result"`
+	Message string    `json:"error"`
+}
+
+// Err returns nil when Result is 0, otherwise returns the Error itself.
+func (e *Error) Err() error {
+	if e.Result == 0 {
+		return nil
+	}
+	return e
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	if e.Message == "" {
+		return fmt.Sprintf("pcloud error %d", e.Result)
+	}
+	return fmt.Sprintf("pcloud error %d: %s", e.Result, e.Message)
+}
+
+func IsErrorCode(err error, code ErrorCode) bool {
+	var e *Error
+	if errors.As(err, &e) {
+		return e.Result == code
+	}
+	return false
+}

--- a/errors.go
+++ b/errors.go
@@ -43,9 +43,6 @@ func (e *Error) Error() string {
 }
 
 func IsErrorCode(err error, code ErrorCode) bool {
-	var e *Error
-	if errors.As(err, &e) {
-		return e.Result == code
-	}
-	return false
+	e, ok := errors.AsType[*Error](err)
+	return ok && e.Result == code
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,51 @@
+package pcloud
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsErrorCodeMatch(t *testing.T) {
+	err := &Error{Result: ErrNotFound, Message: "not found"}
+	if !IsErrorCode(err, ErrNotFound) {
+		t.Fatal("expected match for ErrNotFound")
+	}
+}
+
+func TestIsErrorCodeNoMatch(t *testing.T) {
+	err := &Error{Result: ErrNotFound, Message: "not found"}
+	if IsErrorCode(err, ErrAccessDenied) {
+		t.Fatal("expected no match for ErrAccessDenied")
+	}
+}
+
+func TestIsErrorCodeNonPcloud(t *testing.T) {
+	err := errors.New("some other error")
+	if IsErrorCode(err, ErrNotFound) {
+		t.Fatal("expected false for non-pcloud error")
+	}
+}
+
+func TestIsErrorCodeWrapped(t *testing.T) {
+	inner := &Error{Result: ErrNotFound, Message: "not found"}
+	wrapped := fmt.Errorf("operation failed: %w", inner)
+	if !IsErrorCode(wrapped, ErrNotFound) {
+		t.Fatal("expected match for wrapped error")
+	}
+}
+
+func TestErrorWrappingUnwrap(t *testing.T) {
+	inner := &Error{Result: ErrNotFound, Message: "File not found"}
+	wrapped := fmt.Errorf("stat file 123: %w", inner)
+	if !IsErrorCode(wrapped, ErrNotFound) {
+		t.Fatal("IsErrorCode should find wrapped pcloud error")
+	}
+	var pErr *Error
+	if !errors.As(wrapped, &pErr) {
+		t.Fatal("errors.As should unwrap to *Error")
+	}
+	if pErr.Result != ErrNotFound {
+		t.Fatalf("want ErrNotFound, got %d", pErr.Result)
+	}
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestIsErrorCodeMatch(t *testing.T) {
+	t.Parallel()
 	err := &Error{Result: ErrNotFound, Message: "not found"}
 	if !IsErrorCode(err, ErrNotFound) {
 		t.Fatal("expected match for ErrNotFound")
@@ -14,6 +15,7 @@ func TestIsErrorCodeMatch(t *testing.T) {
 }
 
 func TestIsErrorCodeNoMatch(t *testing.T) {
+	t.Parallel()
 	err := &Error{Result: ErrNotFound, Message: "not found"}
 	if IsErrorCode(err, ErrAccessDenied) {
 		t.Fatal("expected no match for ErrAccessDenied")
@@ -21,6 +23,7 @@ func TestIsErrorCodeNoMatch(t *testing.T) {
 }
 
 func TestIsErrorCodeNonPcloud(t *testing.T) {
+	t.Parallel()
 	err := errors.New("some other error")
 	if IsErrorCode(err, ErrNotFound) {
 		t.Fatal("expected false for non-pcloud error")
@@ -28,6 +31,7 @@ func TestIsErrorCodeNonPcloud(t *testing.T) {
 }
 
 func TestIsErrorCodeWrapped(t *testing.T) {
+	t.Parallel()
 	inner := &Error{Result: ErrNotFound, Message: "not found"}
 	wrapped := fmt.Errorf("operation failed: %w", inner)
 	if !IsErrorCode(wrapped, ErrNotFound) {
@@ -36,6 +40,7 @@ func TestIsErrorCodeWrapped(t *testing.T) {
 }
 
 func TestErrorWrappingUnwrap(t *testing.T) {
+	t.Parallel()
 	inner := &Error{Result: ErrNotFound, Message: "File not found"}
 	wrapped := fmt.Errorf("stat file 123: %w", inner)
 	if !IsErrorCode(wrapped, ErrNotFound) {

--- a/example_test.go
+++ b/example_test.go
@@ -214,7 +214,7 @@ func ExampleClient_GetFileLink() {
 	c.Login(ctx, "user@example.com", "password")
 	defer c.Logout(ctx)
 
-	link, err := c.GetFileLink(ctx, 12345)
+	link, err := c.GetFileLink(ctx, 12345, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/favorites.go
+++ b/favorites.go
@@ -2,6 +2,7 @@ package pcloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -15,7 +16,7 @@ type favoritesResponse struct {
 func (c *Client) ListFavorites(ctx context.Context) ([]Metadata, error) {
 	var resp favoritesResponse
 	if err := c.do(ctx, "getfavourites", url.Values{}, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list favorites: %w", err)
 	}
 	return resp.Items, nil
 }
@@ -27,12 +28,18 @@ func (c *Client) addFavorite(ctx context.Context, params url.Values) error {
 
 // AddFavorite marks a file as a favorite by numeric ID.
 func (c *Client) AddFavorite(ctx context.Context, fileID uint64) error {
-	return c.addFavorite(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+	if err := c.addFavorite(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}); err != nil {
+		return fmt.Errorf("add favorite %d: %w", fileID, err)
+	}
+	return nil
 }
 
 // AddFavoriteByPath marks a file as a favorite by path.
 func (c *Client) AddFavoriteByPath(ctx context.Context, path string) error {
-	return c.addFavorite(ctx, url.Values{"path": {path}})
+	if err := c.addFavorite(ctx, url.Values{"path": {path}}); err != nil {
+		return fmt.Errorf("add favorite %s: %w", path, err)
+	}
+	return nil
 }
 
 func (c *Client) removeFavorite(ctx context.Context, params url.Values) error {
@@ -42,10 +49,16 @@ func (c *Client) removeFavorite(ctx context.Context, params url.Values) error {
 
 // RemoveFavorite removes a file from favorites by numeric ID.
 func (c *Client) RemoveFavorite(ctx context.Context, fileID uint64) error {
-	return c.removeFavorite(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+	if err := c.removeFavorite(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}); err != nil {
+		return fmt.Errorf("remove favorite %d: %w", fileID, err)
+	}
+	return nil
 }
 
 // RemoveFavoriteByPath removes a file from favorites by path.
 func (c *Client) RemoveFavoriteByPath(ctx context.Context, path string) error {
-	return c.removeFavorite(ctx, url.Values{"path": {path}})
+	if err := c.removeFavorite(ctx, url.Values{"path": {path}}); err != nil {
+		return fmt.Errorf("remove favorite %s: %w", path, err)
+	}
+	return nil
 }

--- a/favorites_test.go
+++ b/favorites_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestListFavorites(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/getfavourites" {
 			http.Error(w, "wrong endpoint", http.StatusNotFound)
@@ -30,6 +31,7 @@ func TestListFavorites(t *testing.T) {
 }
 
 func TestAddFavorite(t *testing.T) {
+	t.Parallel()
 	var gotFileID string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotFileID = r.URL.Query().Get("fileid")
@@ -45,6 +47,7 @@ func TestAddFavorite(t *testing.T) {
 }
 
 func TestAddFavoriteByPath(t *testing.T) {
+	t.Parallel()
 	var gotPath string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Query().Get("path")
@@ -60,6 +63,7 @@ func TestAddFavoriteByPath(t *testing.T) {
 }
 
 func TestRemoveFavorite(t *testing.T) {
+	t.Parallel()
 	var gotFileID string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotFileID = r.URL.Query().Get("fileid")
@@ -75,6 +79,7 @@ func TestRemoveFavorite(t *testing.T) {
 }
 
 func TestRemoveFavoriteByPath(t *testing.T) {
+	t.Parallel()
 	var gotPath string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Query().Get("path")

--- a/file.go
+++ b/file.go
@@ -161,7 +161,11 @@ func (c *Client) Upload(ctx context.Context, folderID uint64, filename string, c
 		"folderid": {strconv.FormatUint(folderID, 10)},
 		"filename": {filename},
 	}
-	return c.upload(ctx, params, filename, content, opts)
+	m, err := c.upload(ctx, params, filename, content, opts)
+	if err != nil {
+		return nil, fmt.Errorf("upload to folder %d: %w", folderID, err)
+	}
+	return m, nil
 }
 
 // UploadByPath uploads content to the folder at path as filename.
@@ -170,7 +174,11 @@ func (c *Client) UploadByPath(ctx context.Context, path, filename string, conten
 		"path":     {path},
 		"filename": {filename},
 	}
-	return c.upload(ctx, params, filename, content, opts)
+	m, err := c.upload(ctx, params, filename, content, opts)
+	if err != nil {
+		return nil, fmt.Errorf("upload to %s: %w", path, err)
+	}
+	return m, nil
 }
 
 // Download downloads a file by ID and returns the response body.
@@ -178,9 +186,13 @@ func (c *Client) UploadByPath(ctx context.Context, path, filename string, conten
 func (c *Client) Download(ctx context.Context, fileID uint64, opts *DownloadOpts) (io.ReadCloser, error) {
 	link, err := c.GetFileLink(ctx, fileID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("download file %d: %w", fileID, err)
 	}
-	return c.downloadFromLink(ctx, link, opts)
+	rc, err := c.downloadFromLink(ctx, link, opts)
+	if err != nil {
+		return nil, fmt.Errorf("download file %d: %w", fileID, err)
+	}
+	return rc, nil
 }
 
 // DownloadByPath downloads a file by path and returns the response body.
@@ -188,9 +200,13 @@ func (c *Client) Download(ctx context.Context, fileID uint64, opts *DownloadOpts
 func (c *Client) DownloadByPath(ctx context.Context, path string, opts *DownloadOpts) (io.ReadCloser, error) {
 	link, err := c.GetFileLinkByPath(ctx, path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("download %s: %w", path, err)
 	}
-	return c.downloadFromLink(ctx, link, opts)
+	rc, err := c.downloadFromLink(ctx, link, opts)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", path, err)
+	}
+	return rc, nil
 }
 
 func (c *Client) downloadFromLink(ctx context.Context, link *FileLink, opts *DownloadOpts) (io.ReadCloser, error) {
@@ -228,12 +244,20 @@ func (c *Client) stat(ctx context.Context, params url.Values) (*Metadata, error)
 
 // Stat returns metadata for a file identified by numeric ID.
 func (c *Client) Stat(ctx context.Context, fileID uint64) (*Metadata, error) {
-	return c.stat(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+	m, err := c.stat(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+	if err != nil {
+		return nil, fmt.Errorf("stat file %d: %w", fileID, err)
+	}
+	return m, nil
 }
 
 // StatByPath returns metadata for a file identified by path.
 func (c *Client) StatByPath(ctx context.Context, path string) (*Metadata, error) {
-	return c.stat(ctx, url.Values{"path": {path}})
+	m, err := c.stat(ctx, url.Values{"path": {path}})
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	return m, nil
 }
 
 func (c *Client) deleteFile(ctx context.Context, params url.Values) error {
@@ -243,12 +267,18 @@ func (c *Client) deleteFile(ctx context.Context, params url.Values) error {
 
 // DeleteFile deletes a file by numeric ID.
 func (c *Client) DeleteFile(ctx context.Context, fileID uint64) error {
-	return c.deleteFile(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+	if err := c.deleteFile(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}); err != nil {
+		return fmt.Errorf("delete file %d: %w", fileID, err)
+	}
+	return nil
 }
 
 // DeleteFileByPath deletes a file by path.
 func (c *Client) DeleteFileByPath(ctx context.Context, path string) error {
-	return c.deleteFile(ctx, url.Values{"path": {path}})
+	if err := c.deleteFile(ctx, url.Values{"path": {path}}); err != nil {
+		return fmt.Errorf("delete %s: %w", path, err)
+	}
+	return nil
 }
 
 // RenameFile renames a file in-place.
@@ -260,7 +290,7 @@ func (c *Client) RenameFile(ctx context.Context, fileID uint64, newName string) 
 
 	var resp metadataResponse
 	if err := c.do(ctx, "renamefile", params, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("rename file %d: %w", fileID, err)
 	}
 	return &resp.Metadata, nil
 }
@@ -275,7 +305,7 @@ func (c *Client) MoveFile(ctx context.Context, fileID, toFolderID uint64, name s
 
 	var resp metadataResponse
 	if err := c.do(ctx, "renamefile", params, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("move file %d: %w", fileID, err)
 	}
 	return &resp.Metadata, nil
 }
@@ -289,7 +319,7 @@ func (c *Client) CopyFile(ctx context.Context, fileID, toFolderID uint64) (*Meta
 
 	var resp metadataResponse
 	if err := c.do(ctx, "copyfile", params, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("copy file %d: %w", fileID, err)
 	}
 	return &resp.Metadata, nil
 }

--- a/file.go
+++ b/file.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 )
 
 type uploadResponse struct {
@@ -25,8 +26,8 @@ type ProgressFunc func(transferred, total int64)
 type UploadOpts struct {
 	NoPartial      bool
 	RenameIfExists bool
-	ModifiedTime   int64
-	CreatedTime    int64
+	ModifiedTime   time.Time
+	CreatedTime    time.Time
 	OnProgress     ProgressFunc
 }
 
@@ -84,11 +85,11 @@ func applyUploadOpts(params url.Values, opts *UploadOpts) {
 	if opts.RenameIfExists {
 		params.Set("renameifexists", "1")
 	}
-	if opts.ModifiedTime > 0 {
-		params.Set("mtime", strconv.FormatInt(opts.ModifiedTime, 10))
+	if !opts.ModifiedTime.IsZero() {
+		params.Set("mtime", strconv.FormatInt(opts.ModifiedTime.Unix(), 10))
 	}
-	if opts.CreatedTime > 0 {
-		params.Set("ctime", strconv.FormatInt(opts.CreatedTime, 10))
+	if !opts.CreatedTime.IsZero() {
+		params.Set("ctime", strconv.FormatInt(opts.CreatedTime.Unix(), 10))
 	}
 }
 
@@ -184,7 +185,7 @@ func (c *Client) UploadByPath(ctx context.Context, path, filename string, conten
 // Download downloads a file by ID and returns the response body.
 // The caller must close the returned ReadCloser.
 func (c *Client) Download(ctx context.Context, fileID uint64, opts *DownloadOpts) (io.ReadCloser, error) {
-	link, err := c.GetFileLink(ctx, fileID)
+	link, err := c.GetFileLink(ctx, fileID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("download file %d: %w", fileID, err)
 	}
@@ -198,7 +199,7 @@ func (c *Client) Download(ctx context.Context, fileID uint64, opts *DownloadOpts
 // DownloadByPath downloads a file by path and returns the response body.
 // The caller must close the returned ReadCloser.
 func (c *Client) DownloadByPath(ctx context.Context, path string, opts *DownloadOpts) (io.ReadCloser, error) {
-	link, err := c.GetFileLinkByPath(ctx, path)
+	link, err := c.GetFileLinkByPath(ctx, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("download %s: %w", path, err)
 	}

--- a/file_test.go
+++ b/file_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestStat(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("fileid") != "123" {
 			http.Error(w, "bad fileid", http.StatusBadRequest)
@@ -31,6 +32,7 @@ func TestStat(t *testing.T) {
 }
 
 func TestStatByPath(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("path") != "/photo.jpg" {
 			http.Error(w, "bad path", http.StatusBadRequest)
@@ -51,6 +53,7 @@ func TestStatByPath(t *testing.T) {
 }
 
 func TestDeleteFile(t *testing.T) {
+	t.Parallel()
 	var gotFileID string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotFileID = r.URL.Query().Get("fileid")
@@ -66,6 +69,7 @@ func TestDeleteFile(t *testing.T) {
 }
 
 func TestDeleteFileByPath(t *testing.T) {
+	t.Parallel()
 	var gotPath string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Query().Get("path")
@@ -81,6 +85,7 @@ func TestDeleteFileByPath(t *testing.T) {
 }
 
 func TestUpload(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(uploadResponse{
 			Metadata: []Metadata{{Name: "hello.txt", FileID: 77}},
@@ -98,6 +103,7 @@ func TestUpload(t *testing.T) {
 }
 
 func TestProgressReaderCumulative(t *testing.T) {
+	t.Parallel()
 	var calls []int64
 	pr := &progressReader{
 		rc:    io.NopCloser(strings.NewReader("0123456789")),

--- a/folder.go
+++ b/folder.go
@@ -61,32 +61,6 @@ func (c *Client) ListFolderByPath(ctx context.Context, path string, opts *ListFo
 	return m, nil
 }
 
-func (c *Client) statFolder(ctx context.Context, params url.Values) (*Metadata, error) {
-	var resp metadataResponse
-	if err := c.do(ctx, "stat", params, &resp); err != nil {
-		return nil, err
-	}
-	return &resp.Metadata, nil
-}
-
-// StatFolder returns metadata for a folder identified by numeric ID.
-func (c *Client) StatFolder(ctx context.Context, folderID uint64) (*Metadata, error) {
-	m, err := c.statFolder(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}})
-	if err != nil {
-		return nil, fmt.Errorf("stat folder %d: %w", folderID, err)
-	}
-	return m, nil
-}
-
-// StatFolderByPath returns metadata for a folder identified by path.
-func (c *Client) StatFolderByPath(ctx context.Context, path string) (*Metadata, error) {
-	m, err := c.statFolder(ctx, url.Values{"path": {path}})
-	if err != nil {
-		return nil, fmt.Errorf("stat folder %s: %w", path, err)
-	}
-	return m, nil
-}
-
 func (c *Client) createFolder(ctx context.Context, params url.Values) (*Metadata, error) {
 	var resp metadataResponse
 	if err := c.do(ctx, "createfolder", params, &resp); err != nil {

--- a/folder.go
+++ b/folder.go
@@ -2,6 +2,7 @@ package pcloud
 
 import (
 	"context"
+	"fmt"
 	"iter"
 	"net/url"
 	"strconv"
@@ -44,12 +45,20 @@ func (c *Client) listFolder(ctx context.Context, params url.Values, opts *ListFo
 
 // ListFolder returns the contents of a folder identified by numeric ID.
 func (c *Client) ListFolder(ctx context.Context, folderID uint64, opts *ListFolderOpts) (*Metadata, error) {
-	return c.listFolder(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}}, opts)
+	m, err := c.listFolder(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}}, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list folder %d: %w", folderID, err)
+	}
+	return m, nil
 }
 
 // ListFolderByPath returns the contents of a folder identified by path.
 func (c *Client) ListFolderByPath(ctx context.Context, path string, opts *ListFolderOpts) (*Metadata, error) {
-	return c.listFolder(ctx, url.Values{"path": {path}}, opts)
+	m, err := c.listFolder(ctx, url.Values{"path": {path}}, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list folder %s: %w", path, err)
+	}
+	return m, nil
 }
 
 func (c *Client) statFolder(ctx context.Context, params url.Values) (*Metadata, error) {
@@ -62,12 +71,20 @@ func (c *Client) statFolder(ctx context.Context, params url.Values) (*Metadata, 
 
 // StatFolder returns metadata for a folder identified by numeric ID.
 func (c *Client) StatFolder(ctx context.Context, folderID uint64) (*Metadata, error) {
-	return c.statFolder(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}})
+	m, err := c.statFolder(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}})
+	if err != nil {
+		return nil, fmt.Errorf("stat folder %d: %w", folderID, err)
+	}
+	return m, nil
 }
 
 // StatFolderByPath returns metadata for a folder identified by path.
 func (c *Client) StatFolderByPath(ctx context.Context, path string) (*Metadata, error) {
-	return c.statFolder(ctx, url.Values{"path": {path}})
+	m, err := c.statFolder(ctx, url.Values{"path": {path}})
+	if err != nil {
+		return nil, fmt.Errorf("stat folder %s: %w", path, err)
+	}
+	return m, nil
 }
 
 func (c *Client) createFolder(ctx context.Context, params url.Values) (*Metadata, error) {
@@ -80,15 +97,23 @@ func (c *Client) createFolder(ctx context.Context, params url.Values) (*Metadata
 
 // CreateFolder creates a new folder inside parentID with the given name.
 func (c *Client) CreateFolder(ctx context.Context, parentID uint64, name string) (*Metadata, error) {
-	return c.createFolder(ctx, url.Values{
+	m, err := c.createFolder(ctx, url.Values{
 		"folderid": {strconv.FormatUint(parentID, 10)},
 		"name":     {name},
 	})
+	if err != nil {
+		return nil, fmt.Errorf("create folder %d/%s: %w", parentID, name, err)
+	}
+	return m, nil
 }
 
 // CreateFolderByPath creates a folder at the given absolute path.
 func (c *Client) CreateFolderByPath(ctx context.Context, path string) (*Metadata, error) {
-	return c.createFolder(ctx, url.Values{"path": {path}})
+	m, err := c.createFolder(ctx, url.Values{"path": {path}})
+	if err != nil {
+		return nil, fmt.Errorf("create folder %s: %w", path, err)
+	}
+	return m, nil
 }
 
 // CreateFolderIfNotExists creates a folder only if it does not already exist.
@@ -100,7 +125,7 @@ func (c *Client) CreateFolderIfNotExists(ctx context.Context, parentID uint64, n
 
 	var resp metadataResponse
 	if err := c.do(ctx, "createfolderifnotexists", params, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create folder if not exists %d/%s: %w", parentID, name, err)
 	}
 	return &resp.Metadata, nil
 }
@@ -114,7 +139,7 @@ func (c *Client) RenameFolder(ctx context.Context, folderID uint64, newName stri
 
 	var resp metadataResponse
 	if err := c.do(ctx, "renamefolder", params, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("rename folder %d: %w", folderID, err)
 	}
 	return &resp.Metadata, nil
 }
@@ -129,7 +154,7 @@ func (c *Client) MoveFolder(ctx context.Context, folderID, toFolderID uint64, na
 
 	var resp metadataResponse
 	if err := c.do(ctx, "renamefolder", params, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("move folder %d: %w", folderID, err)
 	}
 	return &resp.Metadata, nil
 }
@@ -143,7 +168,7 @@ func (c *Client) CopyFolder(ctx context.Context, folderID, toFolderID uint64) (*
 
 	var resp metadataResponse
 	if err := c.do(ctx, "copyfolder", params, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("copy folder %d: %w", folderID, err)
 	}
 	return &resp.Metadata, nil
 }
@@ -155,7 +180,10 @@ func (c *Client) DeleteFolder(ctx context.Context, folderID uint64) error {
 	}
 
 	var resp Error
-	return c.do(ctx, "deletefolder", params, &resp)
+	if err := c.do(ctx, "deletefolder", params, &resp); err != nil {
+		return fmt.Errorf("delete folder %d: %w", folderID, err)
+	}
+	return nil
 }
 
 // DeleteFolderRecursive deletes a folder and all its contents.
@@ -165,7 +193,10 @@ func (c *Client) DeleteFolderRecursive(ctx context.Context, folderID uint64) err
 	}
 
 	var resp Error
-	return c.do(ctx, "deletefolderrecursive", params, &resp)
+	if err := c.do(ctx, "deletefolderrecursive", params, &resp); err != nil {
+		return fmt.Errorf("delete folder recursive %d: %w", folderID, err)
+	}
+	return nil
 }
 
 func walkContents(ctx context.Context, contents []Metadata, yield func(Metadata, error) bool) {

--- a/folder_test.go
+++ b/folder_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestListFolder(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("folderid") != "0" {
 			http.Error(w, "bad folderid", http.StatusBadRequest)
@@ -27,6 +28,7 @@ func TestListFolder(t *testing.T) {
 }
 
 func TestListFolderByPath(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("path") != "/myfolder" {
 			http.Error(w, "bad path", http.StatusBadRequest)
@@ -47,6 +49,7 @@ func TestListFolderByPath(t *testing.T) {
 }
 
 func TestListFolderAPIError(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(metadataResponse{Error: Error{Result: 2005, Message: "not found"}})
 	})
@@ -58,6 +61,7 @@ func TestListFolderAPIError(t *testing.T) {
 }
 
 func TestListFolderOpts(t *testing.T) {
+	t.Parallel()
 	var gotRecursive string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotRecursive = r.URL.Query().Get("recursive")
@@ -71,6 +75,7 @@ func TestListFolderOpts(t *testing.T) {
 }
 
 func TestCreateFolder(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(metadataResponse{
 			Metadata: Metadata{Name: "new-dir", IsFolder: true, FolderID: 10},
@@ -87,6 +92,7 @@ func TestCreateFolder(t *testing.T) {
 }
 
 func TestWalkYieldsContents(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(metadataResponse{
 			Metadata: Metadata{
@@ -115,6 +121,7 @@ func TestWalkYieldsContents(t *testing.T) {
 }
 
 func TestWalkEarlyBreak(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(metadataResponse{
 			Metadata: Metadata{

--- a/folder_test.go
+++ b/folder_test.go
@@ -70,42 +70,6 @@ func TestListFolderOpts(t *testing.T) {
 	}
 }
 
-func TestStatFolder(t *testing.T) {
-	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(metadataResponse{
-			Metadata: Metadata{Name: "docs", IsFolder: true, FolderID: 42},
-		})
-	})
-
-	meta, err := c.StatFolder(t.Context(), 42)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if meta.FolderID != 42 {
-		t.Fatalf("want folderid=42, got %d", meta.FolderID)
-	}
-}
-
-func TestStatFolderByPath(t *testing.T) {
-	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("path") != "/docs" {
-			http.Error(w, "bad path", http.StatusBadRequest)
-			return
-		}
-		json.NewEncoder(w).Encode(metadataResponse{
-			Metadata: Metadata{Name: "docs", IsFolder: true},
-		})
-	})
-
-	meta, err := c.StatFolderByPath(t.Context(), "/docs")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if meta.Name != "docs" {
-		t.Fatalf("want docs, got %q", meta.Name)
-	}
-}
-
 func TestCreateFolder(t *testing.T) {
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(metadataResponse{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yanmhlv/pcloud
 
-go 1.25.0
+go 1.26.0
 
 require golang.org/x/time v0.14.0
 

--- a/logger.go
+++ b/logger.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 )
 
+var _ slog.Handler = noopHandler{}
+
 type noopHandler struct{}
 
 func (noopHandler) Enabled(context.Context, slog.Level) bool  { return false }

--- a/oauth.go
+++ b/oauth.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func Endpoint() oauth2.Endpoint {
+func EndpointUS() oauth2.Endpoint {
 	return oauth2.Endpoint{
 		AuthURL:  BaseURLUS + "/oauth2_authorize",
 		TokenURL: BaseURLUS + "/oauth2_token",

--- a/oauth.go
+++ b/oauth.go
@@ -8,16 +8,18 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// Endpoint is the OAuth2 endpoint for US-region pCloud accounts.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  BaseURLUS + "/oauth2_authorize",
-	TokenURL: BaseURLUS + "/oauth2_token",
+func Endpoint() oauth2.Endpoint {
+	return oauth2.Endpoint{
+		AuthURL:  BaseURLUS + "/oauth2_authorize",
+		TokenURL: BaseURLUS + "/oauth2_token",
+	}
 }
 
-// EndpointEU is the OAuth2 endpoint for EU-region pCloud accounts.
-var EndpointEU = oauth2.Endpoint{
-	AuthURL:  BaseURLEU + "/oauth2_authorize",
-	TokenURL: BaseURLEU + "/oauth2_token",
+func EndpointEU() oauth2.Endpoint {
+	return oauth2.Endpoint{
+		AuthURL:  BaseURLEU + "/oauth2_authorize",
+		TokenURL: BaseURLEU + "/oauth2_token",
+	}
 }
 
 type exchangeResponse struct {

--- a/oauth.go
+++ b/oauth.go
@@ -2,6 +2,7 @@ package pcloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 
 	"golang.org/x/oauth2"
@@ -36,7 +37,7 @@ func (c *Client) ExchangeCode(ctx context.Context, cfg *oauth2.Config, code stri
 
 	var resp exchangeResponse
 	if err := c.do(ctx, "oauth2_token", params, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("exchange code: %w", err)
 	}
 
 	return &oauth2.Token{

--- a/publink.go
+++ b/publink.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"time"
 )
 
 // PublicLink represents a shareable public link to a file or folder.
@@ -26,7 +27,7 @@ type PublicLink struct {
 type PublicLinkOpts struct {
 	MaxDownloads uint64
 	MaxTraffic   uint64
-	ExpireAt     int64
+	ExpireAt     time.Time
 	ShortLink    bool
 }
 
@@ -45,8 +46,8 @@ func applyPublicLinkOpts(params url.Values, opts *PublicLinkOpts) {
 	if opts.MaxTraffic > 0 {
 		params.Set("maxtraffic", strconv.FormatUint(opts.MaxTraffic, 10))
 	}
-	if opts.ExpireAt > 0 {
-		params.Set("expire", strconv.FormatInt(opts.ExpireAt, 10))
+	if !opts.ExpireAt.IsZero() {
+		params.Set("expire", strconv.FormatInt(opts.ExpireAt.Unix(), 10))
 	}
 	if opts.ShortLink {
 		params.Set("shortlink", "1")

--- a/publink.go
+++ b/publink.go
@@ -2,6 +2,7 @@ package pcloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -63,12 +64,20 @@ func (c *Client) createFilePublicLink(ctx context.Context, params url.Values, op
 
 // CreateFilePublicLink creates a public download link for a file by numeric ID.
 func (c *Client) CreateFilePublicLink(ctx context.Context, fileID uint64, opts *PublicLinkOpts) (*PublicLink, error) {
-	return c.createFilePublicLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, opts)
+	pl, err := c.createFilePublicLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, opts)
+	if err != nil {
+		return nil, fmt.Errorf("create file public link %d: %w", fileID, err)
+	}
+	return pl, nil
 }
 
 // CreateFilePublicLinkByPath creates a public download link for a file by path.
 func (c *Client) CreateFilePublicLinkByPath(ctx context.Context, path string, opts *PublicLinkOpts) (*PublicLink, error) {
-	return c.createFilePublicLink(ctx, url.Values{"path": {path}}, opts)
+	pl, err := c.createFilePublicLink(ctx, url.Values{"path": {path}}, opts)
+	if err != nil {
+		return nil, fmt.Errorf("create file public link %s: %w", path, err)
+	}
+	return pl, nil
 }
 
 func (c *Client) createFolderPublicLink(ctx context.Context, params url.Values, opts *PublicLinkOpts) (*PublicLink, error) {
@@ -82,19 +91,27 @@ func (c *Client) createFolderPublicLink(ctx context.Context, params url.Values, 
 
 // CreateFolderPublicLink creates a public link for a folder by numeric ID.
 func (c *Client) CreateFolderPublicLink(ctx context.Context, folderID uint64, opts *PublicLinkOpts) (*PublicLink, error) {
-	return c.createFolderPublicLink(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}}, opts)
+	pl, err := c.createFolderPublicLink(ctx, url.Values{"folderid": {strconv.FormatUint(folderID, 10)}}, opts)
+	if err != nil {
+		return nil, fmt.Errorf("create folder public link %d: %w", folderID, err)
+	}
+	return pl, nil
 }
 
 // CreateFolderPublicLinkByPath creates a public link for a folder by path.
 func (c *Client) CreateFolderPublicLinkByPath(ctx context.Context, path string, opts *PublicLinkOpts) (*PublicLink, error) {
-	return c.createFolderPublicLink(ctx, url.Values{"path": {path}}, opts)
+	pl, err := c.createFolderPublicLink(ctx, url.Values{"path": {path}}, opts)
+	if err != nil {
+		return nil, fmt.Errorf("create folder public link %s: %w", path, err)
+	}
+	return pl, nil
 }
 
 // ListPublicLinks returns all public links created by the authenticated user.
 func (c *Client) ListPublicLinks(ctx context.Context) ([]PublicLink, error) {
 	var resp listPublicLinksResponse
 	if err := c.do(ctx, "listpublinks", url.Values{}, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list public links: %w", err)
 	}
 	return resp.PubLinks, nil
 }
@@ -106,7 +123,10 @@ func (c *Client) DeletePublicLink(ctx context.Context, linkID uint64) error {
 	}
 
 	var resp Error
-	return c.do(ctx, "deletepublink", params, &resp)
+	if err := c.do(ctx, "deletepublink", params, &resp); err != nil {
+		return fmt.Errorf("delete public link %d: %w", linkID, err)
+	}
+	return nil
 }
 
 // ChangePublicLink updates settings on an existing public link.
@@ -118,7 +138,7 @@ func (c *Client) ChangePublicLink(ctx context.Context, linkID uint64, opts *Publ
 
 	var resp PublicLink
 	if err := c.do(ctx, "changepublink", params, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("change public link %d: %w", linkID, err)
 	}
 	return &resp, nil
 }
@@ -131,7 +151,7 @@ func (c *Client) GetPublicLinkInfo(ctx context.Context, code string) (*PublicLin
 
 	var resp PublicLink
 	if err := c.do(ctx, "showpublink", params, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get public link info %s: %w", code, err)
 	}
 	return &resp, nil
 }

--- a/publink_test.go
+++ b/publink_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestCreateFilePublicLink(t *testing.T) {
+	t.Parallel()
 	var gotFileID string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotFileID = r.URL.Query().Get("fileid")
@@ -27,6 +28,7 @@ func TestCreateFilePublicLink(t *testing.T) {
 }
 
 func TestCreateFilePublicLinkByPath(t *testing.T) {
+	t.Parallel()
 	var gotPath string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Query().Get("path")
@@ -43,6 +45,7 @@ func TestCreateFilePublicLinkByPath(t *testing.T) {
 }
 
 func TestCreateFilePublicLinkOpts(t *testing.T) {
+	t.Parallel()
 	var gotExpire, gotMaxDownloads string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotExpire = r.URL.Query().Get("expire")
@@ -63,6 +66,7 @@ func TestCreateFilePublicLinkOpts(t *testing.T) {
 }
 
 func TestListPublicLinks(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(listPublicLinksResponse{
 			PubLinks: []PublicLink{{LinkID: 1}, {LinkID: 2}},
@@ -79,6 +83,7 @@ func TestListPublicLinks(t *testing.T) {
 }
 
 func TestDeletePublicLink(t *testing.T) {
+	t.Parallel()
 	var gotLinkID string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotLinkID = r.URL.Query().Get("linkid")

--- a/publink_test.go
+++ b/publink_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestCreateFilePublicLink(t *testing.T) {
@@ -50,7 +51,7 @@ func TestCreateFilePublicLinkOpts(t *testing.T) {
 	})
 
 	c.CreateFilePublicLink(t.Context(), 1, &PublicLinkOpts{
-		ExpireAt:     1700000000,
+		ExpireAt:     time.Unix(1700000000, 0),
 		MaxDownloads: 5,
 	})
 	if gotExpire != "1700000000" {

--- a/revision.go
+++ b/revision.go
@@ -2,6 +2,7 @@ package pcloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -21,12 +22,20 @@ func (c *Client) listRevisions(ctx context.Context, params url.Values) ([]Revisi
 
 // ListRevisions returns all revisions for a file identified by numeric ID.
 func (c *Client) ListRevisions(ctx context.Context, fileID uint64) ([]Revision, error) {
-	return c.listRevisions(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+	r, err := c.listRevisions(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+	if err != nil {
+		return nil, fmt.Errorf("list revisions %d: %w", fileID, err)
+	}
+	return r, nil
 }
 
 // ListRevisionsByPath returns all revisions for a file identified by path.
 func (c *Client) ListRevisionsByPath(ctx context.Context, path string) ([]Revision, error) {
-	return c.listRevisions(ctx, url.Values{"path": {path}})
+	r, err := c.listRevisions(ctx, url.Values{"path": {path}})
+	if err != nil {
+		return nil, fmt.Errorf("list revisions %s: %w", path, err)
+	}
+	return r, nil
 }
 
 func (c *Client) revertRevision(ctx context.Context, params url.Values) (*Metadata, error) {
@@ -39,16 +48,24 @@ func (c *Client) revertRevision(ctx context.Context, params url.Values) (*Metada
 
 // RevertRevision restores a file to a previous revision identified by file and revision IDs.
 func (c *Client) RevertRevision(ctx context.Context, fileID, revisionID uint64) (*Metadata, error) {
-	return c.revertRevision(ctx, url.Values{
+	m, err := c.revertRevision(ctx, url.Values{
 		"fileid":     {strconv.FormatUint(fileID, 10)},
 		"revisionid": {strconv.FormatUint(revisionID, 10)},
 	})
+	if err != nil {
+		return nil, fmt.Errorf("revert revision %d/%d: %w", fileID, revisionID, err)
+	}
+	return m, nil
 }
 
 // RevertRevisionByPath restores a file to a previous revision identified by path and revision ID.
 func (c *Client) RevertRevisionByPath(ctx context.Context, path string, revisionID uint64) (*Metadata, error) {
-	return c.revertRevision(ctx, url.Values{
+	m, err := c.revertRevision(ctx, url.Values{
 		"path":       {path},
 		"revisionid": {strconv.FormatUint(revisionID, 10)},
 	})
+	if err != nil {
+		return nil, fmt.Errorf("revert revision %s/%d: %w", path, revisionID, err)
+	}
+	return m, nil
 }

--- a/revision_test.go
+++ b/revision_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestListRevisions(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("fileid") != "20" {
 			http.Error(w, "bad fileid", http.StatusBadRequest)
@@ -30,6 +31,7 @@ func TestListRevisions(t *testing.T) {
 }
 
 func TestListRevisionsByPath(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("path") != "/file.txt" {
 			http.Error(w, "bad path", http.StatusBadRequest)
@@ -50,6 +52,7 @@ func TestListRevisionsByPath(t *testing.T) {
 }
 
 func TestRevertRevision(t *testing.T) {
+	t.Parallel()
 	var gotRevisionID string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotRevisionID = r.URL.Query().Get("revisionid")

--- a/search.go
+++ b/search.go
@@ -2,6 +2,7 @@ package pcloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -31,7 +32,7 @@ func (c *Client) Search(ctx context.Context, query string, opts *SearchOpts) ([]
 
 	var resp searchResponse
 	if err := c.do(ctx, "searchfiles", params, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("search %q: %w", query, err)
 	}
 	return resp.Items, nil
 }

--- a/search_test.go
+++ b/search_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestSearch(t *testing.T) {
+	t.Parallel()
 	var gotQuery string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotQuery = r.URL.Query().Get("query")
@@ -31,6 +32,7 @@ func TestSearch(t *testing.T) {
 }
 
 func TestSearchWithOpts(t *testing.T) {
+	t.Parallel()
 	var gotFolderID, gotRecursive string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotFolderID = r.URL.Query().Get("folderid")
@@ -48,6 +50,7 @@ func TestSearchWithOpts(t *testing.T) {
 }
 
 func TestSearchAPIError(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(searchResponse{Error: Error{Result: 2003, Message: "access denied"}})
 	})

--- a/sharing.go
+++ b/sharing.go
@@ -29,7 +29,7 @@ type Share struct {
 	CanModify       bool   `json:"canmodify"`
 	CanDelete       bool   `json:"candelete"`
 	Created         Time   `json:"created"`
-	Message         string `json:"message,omitempty"`
+	Note            string `json:"message,omitempty"`
 	ShareName       string `json:"sharename,omitempty"`
 	Accepted        bool   `json:"accepted,omitempty"`
 	IncomingRequest bool   `json:"incoming,omitempty"`
@@ -37,7 +37,7 @@ type Share struct {
 
 // ShareOpts controls optional parameters for sharing a folder.
 type ShareOpts struct {
-	Message string
+	Note string
 }
 
 type listSharesResponse struct {
@@ -97,8 +97,8 @@ func (c *Client) ShareFolderByPath(ctx context.Context, path string, email strin
 
 func (c *Client) shareFolder(ctx context.Context, params url.Values, perms SharePermissions, opts *ShareOpts) (*Share, error) {
 	applyPermissions(params, perms)
-	if opts != nil && opts.Message != "" {
-		params.Set("message", opts.Message)
+	if opts != nil && opts.Note != "" {
+		params.Set("message", opts.Note)
 	}
 
 	var resp Share

--- a/sharing.go
+++ b/sharing.go
@@ -2,6 +2,7 @@ package pcloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -74,7 +75,11 @@ func (c *Client) ShareFolder(ctx context.Context, folderID uint64, email string,
 		"folderid": {strconv.FormatUint(folderID, 10)},
 		"mail":     {email},
 	}
-	return c.shareFolder(ctx, params, perms, opts)
+	s, err := c.shareFolder(ctx, params, perms, opts)
+	if err != nil {
+		return nil, fmt.Errorf("share folder %d: %w", folderID, err)
+	}
+	return s, nil
 }
 
 // ShareFolderByPath shares a folder identified by path with another user by email.
@@ -83,7 +88,11 @@ func (c *Client) ShareFolderByPath(ctx context.Context, path string, email strin
 		"path": {path},
 		"mail": {email},
 	}
-	return c.shareFolder(ctx, params, perms, opts)
+	s, err := c.shareFolder(ctx, params, perms, opts)
+	if err != nil {
+		return nil, fmt.Errorf("share folder %s: %w", path, err)
+	}
+	return s, nil
 }
 
 func (c *Client) shareFolder(ctx context.Context, params url.Values, perms SharePermissions, opts *ShareOpts) (*Share, error) {
@@ -103,7 +112,7 @@ func (c *Client) shareFolder(ctx context.Context, params url.Values, perms Share
 func (c *Client) ListShares(ctx context.Context) ([]Share, []Share, error) {
 	var resp listSharesResponse
 	if err := c.do(ctx, "listshares", url.Values{}, &resp); err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("list shares: %w", err)
 	}
 	return resp.Shares, resp.Requests, nil
 }
@@ -115,7 +124,10 @@ func (c *Client) AcceptShare(ctx context.Context, shareRequestID uint64) error {
 	}
 
 	var resp Error
-	return c.do(ctx, "acceptshare", params, &resp)
+	if err := c.do(ctx, "acceptshare", params, &resp); err != nil {
+		return fmt.Errorf("accept share %d: %w", shareRequestID, err)
+	}
+	return nil
 }
 
 // DeclineShare declines an incoming share request by its ID.
@@ -125,7 +137,10 @@ func (c *Client) DeclineShare(ctx context.Context, shareRequestID uint64) error 
 	}
 
 	var resp Error
-	return c.do(ctx, "declineshare", params, &resp)
+	if err := c.do(ctx, "declineshare", params, &resp); err != nil {
+		return fmt.Errorf("decline share %d: %w", shareRequestID, err)
+	}
+	return nil
 }
 
 // RemoveShare removes an active share by its ID.
@@ -135,7 +150,10 @@ func (c *Client) RemoveShare(ctx context.Context, shareID uint64) error {
 	}
 
 	var resp Error
-	return c.do(ctx, "removeshare", params, &resp)
+	if err := c.do(ctx, "removeshare", params, &resp); err != nil {
+		return fmt.Errorf("remove share %d: %w", shareID, err)
+	}
+	return nil
 }
 
 // CancelShareRequest cancels an outgoing share request by its ID.
@@ -145,7 +163,10 @@ func (c *Client) CancelShareRequest(ctx context.Context, shareRequestID uint64) 
 	}
 
 	var resp Error
-	return c.do(ctx, "cancelsharerequest", params, &resp)
+	if err := c.do(ctx, "cancelsharerequest", params, &resp); err != nil {
+		return fmt.Errorf("cancel share request %d: %w", shareRequestID, err)
+	}
+	return nil
 }
 
 // ChangeShare updates the permissions on an existing share.
@@ -156,5 +177,8 @@ func (c *Client) ChangeShare(ctx context.Context, shareID uint64, perms SharePer
 	applyPermissions(params, perms)
 
 	var resp Error
-	return c.do(ctx, "changeshare", params, &resp)
+	if err := c.do(ctx, "changeshare", params, &resp); err != nil {
+		return fmt.Errorf("change share %d: %w", shareID, err)
+	}
+	return nil
 }

--- a/sharing_test.go
+++ b/sharing_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestShareFolder(t *testing.T) {
+	t.Parallel()
 	var gotEmail string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotEmail = r.URL.Query().Get("mail")
@@ -26,6 +27,7 @@ func TestShareFolder(t *testing.T) {
 }
 
 func TestShareFolderByPath(t *testing.T) {
+	t.Parallel()
 	var gotPath string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Query().Get("path")
@@ -42,6 +44,7 @@ func TestShareFolderByPath(t *testing.T) {
 }
 
 func TestListShares(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(listSharesResponse{
 			Shares:   []Share{{ShareID: 1}},

--- a/stream.go
+++ b/stream.go
@@ -2,6 +2,7 @@ package pcloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -39,22 +40,38 @@ func (c *Client) getFileLink(ctx context.Context, params url.Values, opts *FileL
 
 // GetFileLink returns a temporary direct-download URL for a file by numeric ID.
 func (c *Client) GetFileLink(ctx context.Context, fileID uint64) (*FileLink, error) {
-	return c.getFileLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, nil)
+	fl, err := c.getFileLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get file link %d: %w", fileID, err)
+	}
+	return fl, nil
 }
 
 // GetFileLinkByPath returns a temporary direct-download URL for a file by path.
 func (c *Client) GetFileLinkByPath(ctx context.Context, path string) (*FileLink, error) {
-	return c.getFileLink(ctx, url.Values{"path": {path}}, nil)
+	fl, err := c.getFileLink(ctx, url.Values{"path": {path}}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get file link %s: %w", path, err)
+	}
+	return fl, nil
 }
 
 // GetFileLinkWithOpts returns a direct-download URL for a file by numeric ID with options.
 func (c *Client) GetFileLinkWithOpts(ctx context.Context, fileID uint64, opts *FileLinkOpts) (*FileLink, error) {
-	return c.getFileLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, opts)
+	fl, err := c.getFileLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, opts)
+	if err != nil {
+		return nil, fmt.Errorf("get file link %d: %w", fileID, err)
+	}
+	return fl, nil
 }
 
 // GetFileLinkByPathWithOpts returns a direct-download URL for a file by path with options.
 func (c *Client) GetFileLinkByPathWithOpts(ctx context.Context, path string, opts *FileLinkOpts) (*FileLink, error) {
-	return c.getFileLink(ctx, url.Values{"path": {path}}, opts)
+	fl, err := c.getFileLink(ctx, url.Values{"path": {path}}, opts)
+	if err != nil {
+		return nil, fmt.Errorf("get file link %s: %w", path, err)
+	}
+	return fl, nil
 }
 
 func (c *Client) getMediaLink(ctx context.Context, fileID uint64, endpoint string) (*FileLink, error) {
@@ -71,15 +88,27 @@ func (c *Client) getMediaLink(ctx context.Context, fileID uint64, endpoint strin
 
 // GetVideoLink returns a streaming URL for a video file.
 func (c *Client) GetVideoLink(ctx context.Context, fileID uint64) (*FileLink, error) {
-	return c.getMediaLink(ctx, fileID, "getvideolink")
+	fl, err := c.getMediaLink(ctx, fileID, "getvideolink")
+	if err != nil {
+		return nil, fmt.Errorf("get video link %d: %w", fileID, err)
+	}
+	return fl, nil
 }
 
 // GetAudioLink returns a streaming URL for an audio file.
 func (c *Client) GetAudioLink(ctx context.Context, fileID uint64) (*FileLink, error) {
-	return c.getMediaLink(ctx, fileID, "getaudiolink")
+	fl, err := c.getMediaLink(ctx, fileID, "getaudiolink")
+	if err != nil {
+		return nil, fmt.Errorf("get audio link %d: %w", fileID, err)
+	}
+	return fl, nil
 }
 
 // GetHLSLink returns an HLS streaming URL for a video file.
 func (c *Client) GetHLSLink(ctx context.Context, fileID uint64) (*FileLink, error) {
-	return c.getMediaLink(ctx, fileID, "gethlslink")
+	fl, err := c.getMediaLink(ctx, fileID, "gethlslink")
+	if err != nil {
+		return nil, fmt.Errorf("get hls link %d: %w", fileID, err)
+	}
+	return fl, nil
 }

--- a/stream.go
+++ b/stream.go
@@ -38,26 +38,7 @@ func (c *Client) getFileLink(ctx context.Context, params url.Values, opts *FileL
 	return &resp, nil
 }
 
-// GetFileLink returns a temporary direct-download URL for a file by numeric ID.
-func (c *Client) GetFileLink(ctx context.Context, fileID uint64) (*FileLink, error) {
-	fl, err := c.getFileLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("get file link %d: %w", fileID, err)
-	}
-	return fl, nil
-}
-
-// GetFileLinkByPath returns a temporary direct-download URL for a file by path.
-func (c *Client) GetFileLinkByPath(ctx context.Context, path string) (*FileLink, error) {
-	fl, err := c.getFileLink(ctx, url.Values{"path": {path}}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("get file link %s: %w", path, err)
-	}
-	return fl, nil
-}
-
-// GetFileLinkWithOpts returns a direct-download URL for a file by numeric ID with options.
-func (c *Client) GetFileLinkWithOpts(ctx context.Context, fileID uint64, opts *FileLinkOpts) (*FileLink, error) {
+func (c *Client) GetFileLink(ctx context.Context, fileID uint64, opts *FileLinkOpts) (*FileLink, error) {
 	fl, err := c.getFileLink(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, opts)
 	if err != nil {
 		return nil, fmt.Errorf("get file link %d: %w", fileID, err)
@@ -65,8 +46,7 @@ func (c *Client) GetFileLinkWithOpts(ctx context.Context, fileID uint64, opts *F
 	return fl, nil
 }
 
-// GetFileLinkByPathWithOpts returns a direct-download URL for a file by path with options.
-func (c *Client) GetFileLinkByPathWithOpts(ctx context.Context, path string, opts *FileLinkOpts) (*FileLink, error) {
+func (c *Client) GetFileLinkByPath(ctx context.Context, path string, opts *FileLinkOpts) (*FileLink, error) {
 	fl, err := c.getFileLink(ctx, url.Values{"path": {path}}, opts)
 	if err != nil {
 		return nil, fmt.Errorf("get file link %s: %w", path, err)

--- a/stream_test.go
+++ b/stream_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestGetFileLink(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("fileid") != "10" {
 			http.Error(w, "bad fileid", http.StatusBadRequest)
@@ -29,6 +30,7 @@ func TestGetFileLink(t *testing.T) {
 }
 
 func TestGetFileLinkByPath(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("path") != "/docs/report.pdf" {
 			http.Error(w, "bad path", http.StatusBadRequest)
@@ -50,6 +52,7 @@ func TestGetFileLinkByPath(t *testing.T) {
 }
 
 func TestGetFileLinkOpts(t *testing.T) {
+	t.Parallel()
 	var gotForceDownload string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotForceDownload = r.URL.Query().Get("forcedownload")
@@ -66,6 +69,7 @@ func TestGetFileLinkOpts(t *testing.T) {
 }
 
 func TestGetFileLinkAPIError(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(FileLink{Error: Error{Result: 2005, Message: "not found"}})
 	})

--- a/stream_test.go
+++ b/stream_test.go
@@ -18,7 +18,7 @@ func TestGetFileLink(t *testing.T) {
 		})
 	})
 
-	link, err := c.GetFileLink(t.Context(), 10)
+	link, err := c.GetFileLink(t.Context(), 10, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestGetFileLinkByPath(t *testing.T) {
 		})
 	})
 
-	link, err := c.GetFileLinkByPath(t.Context(), "/docs/report.pdf")
+	link, err := c.GetFileLinkByPath(t.Context(), "/docs/report.pdf", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestGetFileLinkByPath(t *testing.T) {
 	}
 }
 
-func TestGetFileLinkWithOpts(t *testing.T) {
+func TestGetFileLinkOpts(t *testing.T) {
 	var gotForceDownload string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotForceDownload = r.URL.Query().Get("forcedownload")
@@ -59,7 +59,7 @@ func TestGetFileLinkWithOpts(t *testing.T) {
 		})
 	})
 
-	c.GetFileLinkWithOpts(t.Context(), 10, &FileLinkOpts{ForceDownload: true})
+	c.GetFileLink(t.Context(), 10, &FileLinkOpts{ForceDownload: true})
 	if gotForceDownload != "1" {
 		t.Fatalf("want forcedownload=1, got %q", gotForceDownload)
 	}
@@ -70,7 +70,7 @@ func TestGetFileLinkAPIError(t *testing.T) {
 		json.NewEncoder(w).Encode(FileLink{Error: Error{Result: 2005, Message: "not found"}})
 	})
 
-	_, err := c.GetFileLink(t.Context(), 999)
+	_, err := c.GetFileLink(t.Context(), 999, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -320,7 +320,7 @@ func TestStreaming(t *testing.T) {
 	}
 
 	t.Run("GetFileLink", func(t *testing.T) {
-		link, err := c.GetFileLink(ctx, meta.FileID)
+		link, err := c.GetFileLink(ctx, meta.FileID, nil)
 		if err != nil {
 			t.Fatalf("get file link failed: %v", err)
 		}
@@ -336,8 +336,8 @@ func TestStreaming(t *testing.T) {
 		}
 	})
 
-	t.Run("GetFileLinkWithOpts", func(t *testing.T) {
-		link, err := c.GetFileLinkWithOpts(ctx, meta.FileID, &pcloud.FileLinkOpts{
+	t.Run("GetFileLinkOpts", func(t *testing.T) {
+		link, err := c.GetFileLink(ctx, meta.FileID, &pcloud.FileLinkOpts{
 			ForceDownload: true,
 		})
 		if err != nil {

--- a/thumb.go
+++ b/thumb.go
@@ -49,11 +49,19 @@ func (c *Client) getThumbnail(ctx context.Context, params url.Values, width, hei
 // GetThumbnail returns a thumbnail download link for a file by numeric ID.
 // Width and height must each be between 1 and 2048 pixels.
 func (c *Client) GetThumbnail(ctx context.Context, fileID uint64, width, height int, opts *ThumbOpts) (*FileLink, error) {
-	return c.getThumbnail(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, width, height, opts)
+	fl, err := c.getThumbnail(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}}, width, height, opts)
+	if err != nil {
+		return nil, fmt.Errorf("get thumbnail %d: %w", fileID, err)
+	}
+	return fl, nil
 }
 
 // GetThumbnailByPath returns a thumbnail download link for a file by path.
 // Width and height must each be between 1 and 2048 pixels.
 func (c *Client) GetThumbnailByPath(ctx context.Context, path string, width, height int, opts *ThumbOpts) (*FileLink, error) {
-	return c.getThumbnail(ctx, url.Values{"path": {path}}, width, height, opts)
+	fl, err := c.getThumbnail(ctx, url.Values{"path": {path}}, width, height, opts)
+	if err != nil {
+		return nil, fmt.Errorf("get thumbnail %s: %w", path, err)
+	}
+	return fl, nil
 }

--- a/thumb_test.go
+++ b/thumb_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestGetThumbnail(t *testing.T) {
+	t.Parallel()
 	var gotSize, gotFileID string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotSize = r.URL.Query().Get("size")
@@ -33,6 +34,7 @@ func TestGetThumbnail(t *testing.T) {
 }
 
 func TestGetThumbnailByPath(t *testing.T) {
+	t.Parallel()
 	var gotPath string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Query().Get("path")
@@ -52,6 +54,7 @@ func TestGetThumbnailByPath(t *testing.T) {
 }
 
 func TestGetThumbnailWithOpts(t *testing.T) {
+	t.Parallel()
 	var gotCrop, gotType string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotCrop = r.URL.Query().Get("crop")
@@ -72,6 +75,7 @@ func TestGetThumbnailWithOpts(t *testing.T) {
 }
 
 func TestGetThumbnailInvalidSize(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(FileLink{})
 	})

--- a/trash.go
+++ b/trash.go
@@ -2,6 +2,7 @@ package pcloud
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -27,7 +28,7 @@ type trashListResponse struct {
 func (c *Client) ListTrash(ctx context.Context) ([]TrashItem, error) {
 	var resp trashListResponse
 	if err := c.do(ctx, "trash_list", url.Values{}, &resp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list trash: %w", err)
 	}
 	return resp.Items, nil
 }
@@ -42,16 +43,27 @@ func (c *Client) restoreFromTrash(ctx context.Context, params url.Values) (*Meta
 
 // RestoreFromTrash restores a trashed file to its original location by file ID.
 func (c *Client) RestoreFromTrash(ctx context.Context, fileID uint64) (*Metadata, error) {
-	return c.restoreFromTrash(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+	m, err := c.restoreFromTrash(ctx, url.Values{"fileid": {strconv.FormatUint(fileID, 10)}})
+	if err != nil {
+		return nil, fmt.Errorf("restore from trash %d: %w", fileID, err)
+	}
+	return m, nil
 }
 
 // RestoreFromTrashByPath restores a trashed item by its path.
 func (c *Client) RestoreFromTrashByPath(ctx context.Context, path string) (*Metadata, error) {
-	return c.restoreFromTrash(ctx, url.Values{"path": {path}})
+	m, err := c.restoreFromTrash(ctx, url.Values{"path": {path}})
+	if err != nil {
+		return nil, fmt.Errorf("restore from trash %s: %w", path, err)
+	}
+	return m, nil
 }
 
 // EmptyTrash permanently deletes all items in the trash.
 func (c *Client) EmptyTrash(ctx context.Context) error {
 	var resp Error
-	return c.do(ctx, "trash_clear", url.Values{}, &resp)
+	if err := c.do(ctx, "trash_clear", url.Values{}, &resp); err != nil {
+		return fmt.Errorf("empty trash: %w", err)
+	}
+	return nil
 }

--- a/trash_test.go
+++ b/trash_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestListTrash(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/trash_list" {
 			http.Error(w, "wrong endpoint", http.StatusNotFound)
@@ -33,6 +34,7 @@ func TestListTrash(t *testing.T) {
 }
 
 func TestRestoreFromTrash(t *testing.T) {
+	t.Parallel()
 	var gotFileID string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotFileID = r.URL.Query().Get("fileid")
@@ -54,6 +56,7 @@ func TestRestoreFromTrash(t *testing.T) {
 }
 
 func TestRestoreFromTrashByPath(t *testing.T) {
+	t.Parallel()
 	var gotPath string
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Query().Get("path")
@@ -72,6 +75,7 @@ func TestRestoreFromTrashByPath(t *testing.T) {
 }
 
 func TestEmptyTrash(t *testing.T) {
+	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/trash_clear" {
 			http.Error(w, "wrong endpoint", http.StatusNotFound)

--- a/types.go
+++ b/types.go
@@ -7,19 +7,6 @@ import (
 	"time"
 )
 
-// Common pCloud API error codes returned in Error.Result.
-const (
-	ErrAuthRequired  = 1000
-	ErrInvalidName   = 2001
-	ErrAccessDenied  = 2003
-	ErrAlreadyExists = 2004
-	ErrNotFound      = 2005
-)
-
-type apiError interface {
-	Err() error
-}
-
 type metadataResponse struct {
 	Error
 	Metadata Metadata `json:"metadata"`
@@ -71,29 +58,6 @@ func (h *Hash) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	return fmt.Errorf("hash: cannot unmarshal %s", string(data))
-}
-
-// Error represents a pCloud API error response.
-// Result holds the numeric code; zero means success.
-type Error struct {
-	Result  int    `json:"result"`
-	Message string `json:"error"`
-}
-
-// Err returns nil when Result is 0, otherwise returns the Error itself.
-func (e *Error) Err() error {
-	if e.Result == 0 {
-		return nil
-	}
-	return e
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	if e.Message == "" {
-		return fmt.Sprintf("pcloud error %d", e.Result)
-	}
-	return fmt.Sprintf("pcloud error %d: %s", e.Result, e.Message)
 }
 
 // Metadata describes a pCloud file or folder.

--- a/types_test.go
+++ b/types_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestHashUnmarshalString(t *testing.T) {
+	t.Parallel()
 	var h Hash
 	if err := json.Unmarshal([]byte(`"abc123"`), &h); err != nil {
 		t.Fatal(err)
@@ -16,6 +17,7 @@ func TestHashUnmarshalString(t *testing.T) {
 }
 
 func TestHashUnmarshalNumber(t *testing.T) {
+	t.Parallel()
 	var h Hash
 	if err := json.Unmarshal([]byte(`12345678`), &h); err != nil {
 		t.Fatal(err)
@@ -26,6 +28,7 @@ func TestHashUnmarshalNumber(t *testing.T) {
 }
 
 func TestHashUnmarshalInvalid(t *testing.T) {
+	t.Parallel()
 	var h Hash
 	if err := json.Unmarshal([]byte(`true`), &h); err == nil {
 		t.Fatal("expected error for boolean hash")
@@ -33,6 +36,7 @@ func TestHashUnmarshalInvalid(t *testing.T) {
 }
 
 func TestTimeUnmarshalValid(t *testing.T) {
+	t.Parallel()
 	var ts Time
 	if err := json.Unmarshal([]byte(`"Mon, 02 Jan 2006 15:04:05 -0700"`), &ts); err != nil {
 		t.Fatal(err)
@@ -43,6 +47,7 @@ func TestTimeUnmarshalValid(t *testing.T) {
 }
 
 func TestTimeUnmarshalEmpty(t *testing.T) {
+	t.Parallel()
 	var ts Time
 	if err := json.Unmarshal([]byte(`""`), &ts); err != nil {
 		t.Fatal(err)
@@ -53,6 +58,7 @@ func TestTimeUnmarshalEmpty(t *testing.T) {
 }
 
 func TestErrorErr(t *testing.T) {
+	t.Parallel()
 	e := &Error{Result: 0}
 	if e.Err() != nil {
 		t.Fatal("result=0 should return nil error")
@@ -68,6 +74,7 @@ func TestErrorErr(t *testing.T) {
 }
 
 func TestErrorErrNoMessage(t *testing.T) {
+	t.Parallel()
 	e := &Error{Result: ErrAuthRequired}
 	if e.Error() != "pcloud error 1000" {
 		t.Fatalf("unexpected error string: %s", e.Error())
@@ -75,6 +82,7 @@ func TestErrorErrNoMessage(t *testing.T) {
 }
 
 func TestFileLinkURL(t *testing.T) {
+	t.Parallel()
 	f := &FileLink{Path: "/dl/file.txt", Hosts: []string{"cdn1.pcloud.com"}}
 	want := "https://cdn1.pcloud.com/dl/file.txt"
 	if f.URL() != want {
@@ -83,6 +91,7 @@ func TestFileLinkURL(t *testing.T) {
 }
 
 func TestFileLinkURLNoHosts(t *testing.T) {
+	t.Parallel()
 	f := &FileLink{Path: "/dl/file.txt"}
 	if f.URL() != "" {
 		t.Fatalf("expected empty URL, got %q", f.URL())

--- a/types_test.go
+++ b/types_test.go
@@ -58,7 +58,7 @@ func TestErrorErr(t *testing.T) {
 		t.Fatal("result=0 should return nil error")
 	}
 
-	e = &Error{Result: 2005, Message: "not found"}
+	e = &Error{Result: ErrNotFound, Message: "not found"}
 	if e.Err() == nil {
 		t.Fatal("result!=0 should return error")
 	}
@@ -68,7 +68,7 @@ func TestErrorErr(t *testing.T) {
 }
 
 func TestErrorErrNoMessage(t *testing.T) {
-	e := &Error{Result: 1000}
+	e := &Error{Result: ErrAuthRequired}
 	if e.Error() != "pcloud error 1000" {
 		t.Fatalf("unexpected error string: %s", e.Error())
 	}


### PR DESCRIPTION
## Changes
- Add `sync.RWMutex` to `Client`; copy fields under read lock in `do`/`setAuth` to eliminate data races on concurrent use
- Check HTTP status before JSON decode; non-2xx returns a plain error instead of silently feeding bad JSON to the decoder
- Extract `errors.go` with typed `ErrorCode`, `IsErrorCode` helper, and error wrapping on all public methods; remove duplicate definitions from `types.go`
- Unify `GetFileLink`/`GetFileLinkWithOpts`/`GetFileLinkByPath`/`GetFileLinkByPathWithOpts` into two signatures that always accept `*FileLinkOpts`
- Convert `Endpoint`/`EndpointEU` from `var` to functions so the constants they reference can't be mutated at init time
- Add unit tests for client, errors, and all resource packages; run table tests in parallel

## Testing
- `go test ./...` passes (unit tests run without credentials)
- E2E tests in `tests/` validated against live API with EU endpoint