### PR TITLE
refactor: remove Error from public types, simplify bool params

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -43,11 +43,16 @@ func (c *Client) Logout(ctx context.Context) error {
 	return nil
 }
 
+type userInfoResponse struct {
+	Error
+	UserInfo
+}
+
 // UserInfo returns the account details for the authenticated user.
 func (c *Client) UserInfo(ctx context.Context) (*UserInfo, error) {
-	var resp UserInfo
+	var resp userInfoResponse
 	if err := c.do(ctx, "userinfo", url.Values{}, &resp); err != nil {
 		return nil, fmt.Errorf("userinfo: %w", err)
 	}
-	return &resp, nil
+	return &resp.UserInfo, nil
 }

--- a/publink.go
+++ b/publink.go
@@ -10,7 +10,6 @@ import (
 
 // PublicLink represents a shareable public link to a file or folder.
 type PublicLink struct {
-	Error
 	LinkID    uint64   `json:"linkid"`
 	Code      string   `json:"code"`
 	Link      string   `json:"link"`
@@ -54,13 +53,18 @@ func applyPublicLinkOpts(params url.Values, opts *PublicLinkOpts) {
 	}
 }
 
+type publicLinkResponse struct {
+	Error
+	PublicLink
+}
+
 func (c *Client) createFilePublicLink(ctx context.Context, params url.Values, opts *PublicLinkOpts) (*PublicLink, error) {
 	applyPublicLinkOpts(params, opts)
-	var resp PublicLink
+	var resp publicLinkResponse
 	if err := c.do(ctx, "getfilepublink", params, &resp); err != nil {
 		return nil, err
 	}
-	return &resp, nil
+	return &resp.PublicLink, nil
 }
 
 // CreateFilePublicLink creates a public download link for a file by numeric ID.
@@ -83,11 +87,11 @@ func (c *Client) CreateFilePublicLinkByPath(ctx context.Context, path string, op
 
 func (c *Client) createFolderPublicLink(ctx context.Context, params url.Values, opts *PublicLinkOpts) (*PublicLink, error) {
 	applyPublicLinkOpts(params, opts)
-	var resp PublicLink
+	var resp publicLinkResponse
 	if err := c.do(ctx, "getfolderpublink", params, &resp); err != nil {
 		return nil, err
 	}
-	return &resp, nil
+	return &resp.PublicLink, nil
 }
 
 // CreateFolderPublicLink creates a public link for a folder by numeric ID.
@@ -137,11 +141,11 @@ func (c *Client) ChangePublicLink(ctx context.Context, linkID uint64, opts *Publ
 	}
 	applyPublicLinkOpts(params, opts)
 
-	var resp PublicLink
+	var resp publicLinkResponse
 	if err := c.do(ctx, "changepublink", params, &resp); err != nil {
 		return nil, fmt.Errorf("change public link %d: %w", linkID, err)
 	}
-	return &resp, nil
+	return &resp.PublicLink, nil
 }
 
 // GetPublicLinkInfo returns details about a public link identified by its short code.
@@ -150,9 +154,9 @@ func (c *Client) GetPublicLinkInfo(ctx context.Context, code string) (*PublicLin
 		"code": {code},
 	}
 
-	var resp PublicLink
+	var resp publicLinkResponse
 	if err := c.do(ctx, "showpublink", params, &resp); err != nil {
 		return nil, fmt.Errorf("get public link info %s: %w", code, err)
 	}
-	return &resp, nil
+	return &resp.PublicLink, nil
 }

--- a/sharing.go
+++ b/sharing.go
@@ -17,7 +17,6 @@ type SharePermissions struct {
 
 // Share represents a folder sharing record, including both active shares and pending requests.
 type Share struct {
-	Error
 	ShareID         uint64 `json:"shareid"`
 	ShareRequestID  uint64 `json:"sharerequestid"`
 	FolderID        uint64 `json:"folderid"`
@@ -38,6 +37,11 @@ type Share struct {
 // ShareOpts controls optional parameters for sharing a folder.
 type ShareOpts struct {
 	Note string
+}
+
+type shareResponse struct {
+	Error
+	Share
 }
 
 type listSharesResponse struct {
@@ -92,11 +96,11 @@ func (c *Client) shareFolder(ctx context.Context, params url.Values, perms Share
 		params.Set("message", opts.Note)
 	}
 
-	var resp Share
+	var resp shareResponse
 	if err := c.do(ctx, "sharefolder", params, &resp); err != nil {
 		return nil, err
 	}
-	return &resp, nil
+	return &resp.Share, nil
 }
 
 // ListShares returns active shares and pending share requests for the authenticated user.

--- a/sharing.go
+++ b/sharing.go
@@ -46,27 +46,18 @@ type listSharesResponse struct {
 	Requests []Share `json:"requests"`
 }
 
+func boolParam(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
 func applyPermissions(params url.Values, perms SharePermissions) {
-	if perms.CanRead {
-		params.Set("canread", "1")
-	} else {
-		params.Set("canread", "0")
-	}
-	if perms.CanCreate {
-		params.Set("cancreate", "1")
-	} else {
-		params.Set("cancreate", "0")
-	}
-	if perms.CanModify {
-		params.Set("canmodify", "1")
-	} else {
-		params.Set("canmodify", "0")
-	}
-	if perms.CanDelete {
-		params.Set("candelete", "1")
-	} else {
-		params.Set("candelete", "0")
-	}
+	params.Set("canread", boolParam(perms.CanRead))
+	params.Set("cancreate", boolParam(perms.CanCreate))
+	params.Set("canmodify", boolParam(perms.CanModify))
+	params.Set("candelete", boolParam(perms.CanDelete))
 }
 
 // ShareFolder shares a folder identified by numeric ID with another user by email.

--- a/stream.go
+++ b/stream.go
@@ -29,13 +29,18 @@ func applyLinkOpts(params url.Values, opts *FileLinkOpts) {
 	}
 }
 
+type fileLinkResponse struct {
+	Error
+	FileLink
+}
+
 func (c *Client) getFileLink(ctx context.Context, params url.Values, opts *FileLinkOpts) (*FileLink, error) {
 	applyLinkOpts(params, opts)
-	var resp FileLink
+	var resp fileLinkResponse
 	if err := c.do(ctx, "getfilelink", params, &resp); err != nil {
 		return nil, err
 	}
-	return &resp, nil
+	return &resp.FileLink, nil
 }
 
 func (c *Client) GetFileLink(ctx context.Context, fileID uint64, opts *FileLinkOpts) (*FileLink, error) {
@@ -59,11 +64,11 @@ func (c *Client) getMediaLink(ctx context.Context, fileID uint64, endpoint strin
 		"fileid": {strconv.FormatUint(fileID, 10)},
 	}
 
-	var resp FileLink
+	var resp fileLinkResponse
 	if err := c.do(ctx, endpoint, params, &resp); err != nil {
 		return nil, err
 	}
-	return &resp, nil
+	return &resp.FileLink, nil
 }
 
 // GetVideoLink returns a streaming URL for a video file.

--- a/stream_test.go
+++ b/stream_test.go
@@ -71,7 +71,7 @@ func TestGetFileLinkOpts(t *testing.T) {
 func TestGetFileLinkAPIError(t *testing.T) {
 	t.Parallel()
 	c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(FileLink{Error: Error{Result: 2005, Message: "not found"}})
+		json.NewEncoder(w).Encode(Error{Result: 2005, Message: "not found"})
 	})
 
 	_, err := c.GetFileLink(t.Context(), 999, nil)

--- a/thumb.go
+++ b/thumb.go
@@ -13,6 +13,11 @@ type ThumbOpts struct {
 	Type string // "png" or "jpeg"; defaults to "png" if empty
 }
 
+type thumbResponse struct {
+	Error
+	FileLink
+}
+
 func applyThumbOpts(params url.Values, opts *ThumbOpts) {
 	if opts == nil {
 		return
@@ -39,11 +44,11 @@ func (c *Client) getThumbnail(ctx context.Context, params url.Values, width, hei
 	params.Set("size", fmt.Sprintf("%dx%d", width, height))
 	applyThumbOpts(params, opts)
 
-	var resp FileLink
+	var resp thumbResponse
 	if err := c.do(ctx, "getthumb", params, &resp); err != nil {
 		return nil, err
 	}
-	return &resp, nil
+	return &resp.FileLink, nil
 }
 
 // GetThumbnail returns a thumbnail download link for a file by numeric ID.

--- a/types.go
+++ b/types.go
@@ -92,7 +92,6 @@ type Revision struct {
 
 // UserInfo holds account details returned by the userinfo endpoint.
 type UserInfo struct {
-	Error
 	UserID         uint64 `json:"userid"`
 	Email          string `json:"email"`
 	EmailVerified  bool   `json:"emailverified"`
@@ -106,7 +105,6 @@ type UserInfo struct {
 
 // FileLink holds a temporary direct-download URL returned by streaming endpoints.
 type FileLink struct {
-	Error
 	Path    string   `json:"path"`
 	Expires string   `json:"expires"`
 	Hosts   []string `json:"hosts"`


### PR DESCRIPTION
## Changes
- Remove `Error` embedding from `UserInfo`, `FileLink`, `PublicLink`, and `Share` — these are return types and should not expose API error fields
- Introduce private `*Response` wrapper structs that embed both `Error` and the public type, used only inside method bodies
- Replace 4 if/else pairs in `applyPermissions` with a `boolParam` helper

## Why
Public types embedding `Error` leaks internal API plumbing into the library's surface. Callers only receive these types on success (errors are returned via the `error` return value), so the embedded `Error` fields were dead weight and violated the single-responsibility rule.

## Testing
- Existing tests pass; `stream_test.go` updated to match the new `FileLink` shape (no longer embeds `Error`)
- Build and lint clean